### PR TITLE
Show URL of published content

### DIFF
--- a/rsconnect/static/connect.js
+++ b/rsconnect/static/connect.js
@@ -480,7 +480,7 @@ define([
     var txtApiKey = null;
     var txtTitle = null;
 
-    var maybeDisableTitle = function() {
+    function maybeDisableTitle() {
       var entry = config.servers[selectedEntryId];
       // if title was already set for this notebook
       if (entry && entry.notebookTitle) {
@@ -488,9 +488,9 @@ define([
       } else {
         txtTitle.removeAttr("disabled");
       }
-    };
+    }
 
-    var maybeShowConfigUrl = function() {
+    function maybeShowConfigUrl() {
       var entry = config.servers[selectedEntryId];
       if (entry && entry.configUrl) {
         publishModal
@@ -509,7 +509,7 @@ define([
           .find("a")
           .remove();
       }
-    };
+    }
 
     var publishModal = Dialog.modal({
       // pass the existing keyboard manager so all shortcuts are disabled while


### PR DESCRIPTION
### Description

Show the URL of the published content so the user knows where it is.

Connected to rstudio/connect#10128

![image](https://user-images.githubusercontent.com/193628/41377902-c078fd50-6f1a-11e8-8310-961ba3777337.png)


### Testing Notes / Validation Steps

- publish a notebook
- [ ] on subsequent publishing to the same Connect server, the Connect URL of the content is shown
- [ ] switching to servers where the content was not published does not show a URL