### PR TITLE
Add virtualenv recommendation in install guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,8 +18,8 @@ Download the `rsconnect` python package from
 [here](https://github.com/rstudio/rsconnect-jupyter/releases)
 (packaged as a [wheel](https://pythonwheels.com/) file).
 
-We recommend working within a `virtualenv` (especially on a Mac).  If you 
-are unfamiliar, these commands would create and activate a `virtualenv` 
+We recommend working within a `virtualenv` (especially on Mac).  If you 
+are unfamiliar, these commands create and activate a `virtualenv` 
 at `/my/path`:
 
 ```


### PR DESCRIPTION
Add information / recommendation about using a `virtualenv`.  

I'm not super familiar, so I'm open to suggestions on how / where we make this clear to users.
