### PR TITLE
App search correctly applies role restriction

### DIFF
--- a/rsconnect/rsconnect.py
+++ b/rsconnect/rsconnect.py
@@ -123,7 +123,7 @@ class RSConnect:
         self.request('GET', '/__api__/me', None, self.http_headers)
         return self.json_response()
 
-    def app_find(self, filters = {}):
+    def app_find(self, filters):
         params = urlencode(filters)
         self.request('GET', '/__api__/applications?' + params, None, self.http_headers)
         data = self.json_response()
@@ -210,11 +210,10 @@ def deploy(scheme, host, port, api_key, app_id, app_title, tarball):
 def app_search(scheme, host, port, api_key, app_title):
     with RSConnect(scheme, host, api_key, port) as api:
         me = api.me()
-        filters = {'count': 5,
-                   'filter': 'min_role:editor',
-                   'filter': 'account_id:%d' % me['id'],
-                   'search': app_title,
-                   }
+        filters = [('count', 5),
+                   ('filter', 'min_role:editor'),
+                   ('filter', 'account_id:%d' % me['id']),
+                   ('search', app_title)]
         apps = api.app_find(filters)
         if apps is None:
             return []


### PR DESCRIPTION
### Description

Filters were previously incorrectly specified as a duplicate key existed in the
dictionary. In order to support duplicate query parameters we can specify them
as a list of tuples which `urlencode` can correctly encode.

Connected to #23

### Testing Notes / Validation Steps

- Ensure a user has `viewer` permissions on some content - e.g. `Foobar`
    - e.g. user X publishes some content and gives user Y viewer permission
- Deploy notebook as user Y with title `Foo` (prefix of the ^)
    - [ ] content selection dialog __should not__ be brought up (app should be published)

<br>

- Ensure a user has `editor` permissions on some content - e.g. `Foobar`
    - e.g. user X publishes some content and gives user Y collaborator permission
- Deploy notebook as user Y with title `Foo` (prefix of the ^)
    - [ ] content selection __should__ be brought up (app should be published)