### PR TITLE
Relax search scope so content a user can edit shows up

### DIFF
--- a/rsconnect/rsconnect.py
+++ b/rsconnect/rsconnect.py
@@ -212,10 +212,8 @@ def deploy(uri, api_key, app_id, app_title, tarball):
 
 def app_search(uri, api_key, app_title):
     with RSConnect(uri, api_key) as api:
-        me = api.me()
         filters = [('count', 5),
                    ('filter', 'min_role:editor'),
-                   ('filter', 'account_id:%d' % me['id']),
                    ('search', app_title)]
         apps = api.app_find(filters)
         if apps is None:


### PR DESCRIPTION
Removal of the account_id filter enables content that the user has
edit/collaboration permissions on to be selectable.

### Description

Connected to #40 

### Testing Notes / Validation Steps

On initial deploy and document renames (prefixes), content the user is a collaborator on also shows up in the content selection dialog.
- User 1 deploys content with title `Foobar`
- User 1 adds User 2 as collaborator on `Foobar`
- User 2 deploys content called `Foo`
- [ ] User 2 should be shown `Foobar` (content that User 2 is a collaborator on)