### PR TITLE
Ask whether to update or new location on title change

### DIFF
--- a/rsconnect/__init__.py
+++ b/rsconnect/__init__.py
@@ -95,6 +95,7 @@ class EndpointHandler(APIHandler):
             uri = urlparse(data['server_address'])
             app_id = data['app_id'] if 'app_id' in data else None
             nb_title = data['notebook_title']
+            nb_name = data['notebook_name']
             nb_path = unquote_plus(data['notebook_path'].strip('/'))
             api_key = data['api_key']
 
@@ -151,7 +152,7 @@ class EndpointHandler(APIHandler):
                 # rewind file pointer
                 bundle.seek(0)
                 try:
-                    published_app = deploy(uri, api_key, app_id, nb_title, bundle)
+                    published_app = deploy(uri, api_key, app_id, nb_name, nb_title, bundle)
                 except RSConnectException as exc:
                     raise web.HTTPError(400, exc.message)
 

--- a/rsconnect/rsconnect.py
+++ b/rsconnect/rsconnect.py
@@ -187,18 +187,18 @@ def mk_manifest(file_name):
     })
 
 
-def deploy(uri, api_key, app_id, app_title, tarball):
+def deploy(uri, api_key, app_id, app_name, app_title, tarball):
     with RSConnect(uri, api_key) as api:
         if app_id is None:
             # create an app if id is not provided
-            app = api.app_create(app_title)
+            app = api.app_create(app_name)
         else:
             # assume app exists. if it was deleted then Connect will
             # raise an error
             app = api.app_get(app_id)
 
-            if app['title'] != app_title:
-                api.app_update(app_id, {'title': app_title})
+        if app['title'] != app_title:
+            api.app_update(app['id'], {'title': app_title})
 
         app_bundle = api.app_upload(app['id'], tarball)
         task = api.app_deploy(app['id'], app_bundle['id'])

--- a/rsconnect/static/connect.js
+++ b/rsconnect/static/connect.js
@@ -180,6 +180,7 @@ define([
       var data = {
         notebook_path: notebookPath,
         notebook_title: notebookTitle,
+        notebook_name: this.getNotebookName(notebookTitle),
         app_id: appId,
         server_address: entry.server,
         api_key: apiKey
@@ -241,6 +242,10 @@ define([
       });
     },
 
+    getNotebookName: function(title) {
+      return title.replace(/[^a-zA-Z0-9_-]+/g, "_");
+    },
+
     getNotebookTitle: function(id) {
       if (id) {
         // it's possible the entry is gone
@@ -251,15 +256,7 @@ define([
         }
       }
       // default title - massage the title so it validates
-      var title = Jupyter.notebook
-        .get_notebook_name()
-        .split("")
-        .map(function(c) {
-          if (/[a-zA-Z0-9_-]/.test(c)) return c;
-          else return "_";
-        })
-        .join("");
-      return title;
+      return Jupyter.notebook.get_notebook_name();
     }
   };
 
@@ -653,7 +650,7 @@ define([
           publishModal.find(".help-block").text("");
 
           var validApiKey = txtApiKey.val().length === 32;
-          var validTitle = /^[a-zA-Z0-9_-]{3,64}$/.test(txtTitle.val());
+          var validTitle = txtTitle.val().length >= 3;
 
           addValidationMarkup(
             validApiKey,
@@ -663,7 +660,7 @@ define([
           addValidationMarkup(
             validTitle,
             txtTitle,
-            "Title must be between 3 and 64 alphanumeric characters, dashes, and underscores."
+            "Title must be at least 3 characters."
           );
 
           function enablePublishButton() {


### PR DESCRIPTION
### Description

When the title has been edited, ensure that the Search dialog is presented.

Previously, if there was no content matching by title, the Search dialog was suppressed and publication always used a New location. Now, the Search dialog is always presented if there is a match by title OR by the existing app ID. The dialog presents the New location, any existing content matching by title (none in this scenario), and the current location (i.e. matching by app ID). This gives the New/Replace behavior requested in the original issue.

Also if the user chooses to overwrite an existing app, that app's title will be updated to match.

Connected to #25 

### Testing Notes / Validation Steps

* [x] Publish a notebook, entering a unique title. You should not see the Search dialog.
* [x] Open the publish window again, edit the title to something new, and click Publish. The Search dialog should be displayed and show choices of: (1) New, and (2) the previously published location. The previous location should match by ID.
* [x] Create another notebook and publish it. Then open the publish window again, edit the title to match the name from the previous test, and click Publish. The Search dialog should be displayed and show choices of: (1) New, (2) the notebook published from the first test (which matches by title), and (3) the previously published location of this notebook (which matches by ID).
