### PR TITLE
Deployment task polling

### DIFF
--- a/rsconnect/rsconnect.py
+++ b/rsconnect/rsconnect.py
@@ -191,7 +191,7 @@ def mk_manifest(file_name):
     })
 
 
-def wait_for_task(api, task_id, timeout, period=0.1):
+def wait_for_task(api, task_id, timeout, period=1.0):
     last_status = None
     ending = time.time() + timeout
 


### PR DESCRIPTION
### Description

Based on the comments in #53, this PR makes 2 changes to the deployment task status polling:
* Timeout is now based on time since the last status change, rather than being a limit on the overall deployment time.
* We pass in the `first_status` parameter so we are incrementally fetching only the newest statuses.

Connected to #25

### Testing Notes / Validation Steps

Run a deployment of a new notebook. Observe in the notebook server logs that there are two separate log lines similar to:
```
INFO:rsconnect:Deployment status: ['Building static content...']
INFO:rsconnect:Deployment status: ['Launching static content...']
```
