### PR TITLE
JS cleanup

### DIFF
--- a/rsconnect/static/connect.js
+++ b/rsconnect/static/connect.js
@@ -369,7 +369,7 @@ define([
         var $txtServer = serverModal.find("#rsc-server");
         var $txtServerName = serverModal.find("#rsc-servername");
 
-        function enableAddButton(state) {
+        function toggleAddButton(state) {
           serverModal.find("fieldset").attr("disabled", state ? null : true);
           serverModal
             .find(".modal-footer .btn:last")
@@ -402,7 +402,7 @@ define([
           );
 
           if (validServer && validServerName) {
-            enableAddButton(false);
+            toggleAddButton(false);
 
             config
               .addServer($txtServer.val(), $txtServerName.val())
@@ -420,7 +420,7 @@ define([
                 );
               })
               .always(function() {
-                enableAddButton(true);
+                toggleAddButton(true);
               });
           }
         });
@@ -661,7 +661,7 @@ define([
             "Title must be at least 3 characters."
           );
 
-          function enablePublishButton(enabled) {
+          function togglePublishButton(enabled) {
             btnPublish
               .toggleClass("disabled", !enabled)
               .find("i.fa")
@@ -701,7 +701,7 @@ define([
                 txtTitle.val()
               )
               .always(function() {
-                enablePublishButton(true);
+                togglePublishButton(true);
               })
               .fail(handleFailure)
               .then(function() {
@@ -710,7 +710,7 @@ define([
           }
 
           if (selectedEntryId !== null && validApiKey && validTitle) {
-            enablePublishButton(false);
+            togglePublishButton(false);
 
             var currentNotebookTitle =
               config.servers[selectedEntryId].notebookTitle;
@@ -729,7 +729,9 @@ define([
                     txtTitle.val(),
                     currentAppId
                   )
-                  .always(enablePublishButton)
+                  .always(function() {
+                    togglePublishButton(true);
+                  })
                   .fail(handleFailure)
                   .then(function(searchResults) {
                     if (searchResults.length === 0) {


### PR DESCRIPTION
### Description

Some minor JS cleanup / factoring.

Connected to #39

### Testing Notes / Validation Steps

* [ ] Verify that the enable/disable behavior of the dialog action buttons is still correct in the Add Server and Publish dialogs. They should become disabled temporarily once clicked, and become enabled again after the attempt completes. This is easiest to do in an error case because the dialogs stay open on error.
* [ ] Verify that errors related to the primary action in both dialogs are displayed correctly.

Useful error cases for these dialogs are:
* [ ] Try to add an invalid server (e.g. http://foo.bar:3939) in the Add Server dialog
* [ ] Stop Connect, then try to Publish in the Publish dialog
