### PR TITLE
add the new PNG images to the package manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
 include rsconnect/static/*.js
 include rsconnect/static/main.css
+include rsconnect/static/images/*.png


### PR DESCRIPTION
### Description

The images added in #58 weren't added to the package manifest. This doesn't show up in the dev environment because we don't build and install the .whl. Testing the built package is needed to catch this.

Connected to #39

### Testing Notes / Validation Steps

* `make dist`
* create and activate a python environment in a container; don't use `make shell` for this since that will install from the source tree
* `pip install dist/rsconnect-1.0.0-py2.py3-none-any.whl`
* `jupyter-nbextension install --symlink --user --py rsconnect`
* `jupyter-nbextension enable --py rsconnect`
* `jupyter-serverextension enable --py rsconnect`
* `jupyter-notebook -y --notebook-dir=/notebooks --ip='*' --port=9999 --no-browser --NotebookApp.token=''`

Create a notebook, open rsconnect, see that the images in the UI are present.