### PR TITLE
Add dist-run targets for testing the built package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ package:
 
 run:
 # link python package
-	python setup.py install
+	python setup.py develop
 # install rsconnect as a jupyter extension
 	jupyter-nbextension install --symlink --user --py rsconnect
 # enable js extension


### PR DESCRIPTION
### Description

This PR adds targets that run rsconnect-jupyter from the built wheel package instead of from source. This enables easier testing of the final release and will help us catch packaging issues such as the one fixed in #61.

Connected to #39

### Testing Notes / Validation Steps

`make dist-run2` or `make dist-run3` will build the package (`dist/rsconnect-1.0.0-py2.py3-none-any.whl`), install it, and run a notebook server in a container. This is like `make notebook2` but installs from the package instead of the source tree.