### PR TITLE
send failure notification to the right team

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,7 +134,7 @@ try {
   // CC the whole connect team.
   slackNameFail = "unknown"
   if (!isUserBranch) {
-    slackNameFail = "${gitAuthor} (cc @kenny)"
+    slackNameFail = "${gitAuthor} (cc @nand)"
   }
 
   message = "${messagePrefix} by ${slackNameFail} failed: ${err}"


### PR DESCRIPTION
### Description

Failure notifications are being sent to kenny, should be nand.

### Testing Notes / Validation Steps

Failed build notifications in Slack should ping nand and not kenny.