### PR TITLE
select server on entry if there is only one

### DIFF
--- a/rsconnect/static/connect.js
+++ b/rsconnect/static/connect.js
@@ -493,6 +493,12 @@ define([
     selectedAppMode
   ) {
     var dialogResult = $.Deferred();
+
+    var servers = Object.keys(config.servers);
+    if (servers.length == 1) {
+      serverId = servers[0];
+    }
+
     var selectedEntryId = serverId;
 
     var entry = config.servers[selectedEntryId];


### PR DESCRIPTION
### Description

When bringing up the Publish dialog, if there is only one server defined, select it by default. Noticed this as a rough edge during the CG call.

Connected to #70

### Testing Notes / Validation Steps

* Create a new notebook
* Click the Publish button
* Add a server
* Enter API key and publish
* Bring up the Publish dialog again
- [x] The one (and only) server should already be highlighted in blue. Just enter the API key and click Publish and it should republish the notebook.

