### PR TITLE
fix bucket name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ def buildAndTest(pyVersion) {
 
 def publishArtifacts() {
     // Promote master builds to S3
-    cmd = '~/.local/bin/aws s3 cp --exclude "*" --include "*.whl" dist/ s3://studio-rsconnect-jupyter/'
+    cmd = '~/.local/bin/aws s3 cp --exclude "*" --include "*.whl" dist/ s3://rstudio-rsconnect-jupyter/'
 
     if (isUserBranch) {
         print "S3 sync DRY RUN for user branch ${env.BRANCH_NAME}"


### PR DESCRIPTION
### Description

#68 used the wrong s3 bucket name. Unhelpfully, the --dry-run check on the PR branch didn't catch this, and when the master build upload failed there was no error message from `aws s3 cp`. 

Connected to #67 

### Testing Notes / Validation Steps
Same as #68:
* Find the artifact name in Jenkins, e.g. `rsconnect-1.1.0.5-py2.py3-none-any.whl`
* `aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect-1.1.0.5-py2.py3-none-any.whl .` should download the artifact
