### PR TITLE
UX tweaks

### DIFF
--- a/rsconnect/static/connect.js
+++ b/rsconnect/static/connect.js
@@ -636,7 +636,7 @@ define([
         "        </div>",
         "    </div>",
         '    <div class="form-group">',
-        '        <label>API Key</label>  <a href="http://docs.rstudio.com/connect/user/api-keys.html" target="_rsconnect"><i class="fa fa-question-circle rsc-fa-icon" target="_rsconnect"></i></a>',
+        '        <label>API Key</label><a href="http://docs.rstudio.com/connect/user/api-keys.html" target="_rsconnect"><i class="fa fa-question-circle rsc-fa-icon" target="_rsconnect"></i></a>',
         '        <input class="form-control" name="api-key" type="password" maxlength="32" required>',
         '        <span class="help-block"></span>',
         "    </div>",
@@ -645,7 +645,7 @@ define([
         '        <input class="form-control" name="title" type="text" minlength="3" maxlength="64" required>',
         '        <span class="help-block"></span>',
         "    </div>",
-        '    <div class="form-group">',
+        '    <div class="form-group" id="rsc-publish-source">',
         "        <label>Publish Source Code</label>",
         '        <div class="list-group">',
         '            <a href="#" id="rsc-publish-with-source" class="list-group-item rsc-appmode" data-appmode="jupyter-static">',
@@ -747,14 +747,18 @@ define([
               .removeClass("active");
           });
         } else {
+          appModeChoices.addClass("disabled");
+
           var msg =
             "You can't change the mode of an existing deployment. " +
             "To deploy a new deployment, change the title, " +
             'click "Next", select "New location", and then ' +
             "you’ll be able to pick a new mode and publish.";
 
-          appModeChoices
-            .addClass("disabled")
+          var helpIcon = $('<i class="fa fa-question-circle rsc-fa-icon"></i>');
+          $("#rsc-publish-source > label").append(helpIcon);
+
+          $("#rsc-publish-source")
             .data("toggle", "popover")
             .data("placement", "top")
             .data("content", msg)

--- a/rsconnect/static/main.css
+++ b/rsconnect/static/main.css
@@ -27,4 +27,6 @@
 
 .rsc-fa-icon {
     font-size: 18px;
+    color: black;
+    padding-left: 10px;
 }


### PR DESCRIPTION
### Description

Minor UX improvements based on the google doc referenced in #75.

Connected to #75

### Testing Notes / Validation Steps
From the [google doc](https://docs.google.com/document/d/1v8fyPXIdq2jDIZn-KiY8sAheK1S4Tfrmu9b6CECPBwU/edit?usp=sharing):

First, publish the notebook (finished document). Then return to the publish dialog.

In the Publish dialog:
* [x] changing the title, the “Publish” button changes to “Next” to indicate that a further choice is necessary
* The Publish Source code options are grayed out. There is a help icon next to the title. Clicking it shows a help message.

In the Select Deployment Location dialog:
* [x] "New location" entry now includes the title that will be used
* [x] There is an "Or update" heading before the possible locations to overwrite
* [x]  If “New Location” is selected, “Deploy” button changes to “Next” 

If New Location was selected, upon returning to the Publish dialog:
* [x] Edit boxes for API key and title are disabled
* [x] Publish Source selection is now enabled
* [x] Previous App URL at the bottom is no longer shown 


