### PR TITLE
Use package relative imports

### DIFF
--- a/rsconnect/__init__.py
+++ b/rsconnect/__init__.py
@@ -7,8 +7,8 @@ from notebook.base.handlers import APIHandler
 from notebook.utils import url_path_join
 from tornado import web
 
-from rsconnect.api import app_get, app_search, deploy, verify_server, RSConnectException
-from rsconnect.bundle import make_html_bundle, make_source_bundle
+from .api import app_get, app_search, deploy, verify_server, RSConnectException
+from .bundle import make_html_bundle, make_source_bundle
 
 __version__ = '1.0.0'
 


### PR DESCRIPTION
### Description

Before this fix I could not run `make notebook2`.  It would fail with the following error:
```
Using /home/builder/.conda/envs/py2/lib/python2.7/site-packages
Finished processing dependencies for rsconnect==1.1.0.9999
jupyter-nbextension install --symlink --user --py rsconnect
Traceback (most recent call last):
  File "/home/builder/.conda/envs/py2/bin/jupyter-nbextension", line 11, in <module>
    load_entry_point('notebook', 'console_scripts', 'jupyter-nbextension')()
  File "/home/builder/.conda/envs/py2/lib/python2.7/site-packages/jupyter_core/application.py", line 266, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/home/builder/.conda/envs/py2/lib/python2.7/site-packages/traitlets/config/application.py", line 658, in launch_instance
    app.start()
  File "/home/builder/.conda/envs/py2/lib/python2.7/site-packages/notebook/nbextensions.py", line 988, in start
    super(NBExtensionApp, self).start()
  File "/home/builder/.conda/envs/py2/lib/python2.7/site-packages/jupyter_core/application.py", line 255, in start
    self.subapp.start()
  File "/home/builder/.conda/envs/py2/lib/python2.7/site-packages/notebook/nbextensions.py", line 716, in start
    self.install_extensions()
  File "/home/builder/.conda/envs/py2/lib/python2.7/site-packages/notebook/nbextensions.py", line 695, in install_extensions
    **kwargs
  File "/home/builder/.conda/envs/py2/lib/python2.7/site-packages/notebook/nbextensions.py", line 211, in install_nbextension_python
    m, nbexts = _get_nbextension_metadata(module)
  File "/home/builder/.conda/envs/py2/lib/python2.7/site-packages/notebook/nbextensions.py", line 1122, in _get_nbextension_metadata
    m = import_item(module)
  File "/home/builder/.conda/envs/py2/lib/python2.7/site-packages/traitlets/utils/importstring.py", line 42, in import_item
    return __import__(parts[0])
  File "/rsconnect/rsconnect/__init__.py", line 10, in <module>
    from rsconnect.api import app_get, app_search, deploy, verify_server, RSConnectException
ImportError: No module named api
/rsconnect/Makefile:59: recipe for target 'run' failed
make: *** [run] Error 1
make[1]: *** [Makefile:25: launch] Error 2
make[1]: Leaving directory '/home/jonathan/src/rstudio/rsconnect-jupyter'
make: *** [Makefile:37: notebook2] Error 2
```


### Testing Notes / Validation Steps

