### PR TITLE
Make name unique

### DIFF
--- a/rsconnect/static/connect.js
+++ b/rsconnect/static/connect.js
@@ -277,6 +277,8 @@ define([
     },
 
     getNotebookName: function(title) {
+      // slugify title and make it unique, also ensuring that it
+      // fits in the 64 character limit after the timestamp is appended.
       return (
         title.replace(/[^a-zA-Z0-9_-]+/g, "_").substring(0, 50) +
         "-" +


### PR DESCRIPTION
### Description

Ensure that the app name is unique.

When deploying, we set the name based on the title. However, while it's possible to publish two apps with the same title, it fails because the names must be unique. We already present the search dialog when the title is edited, allowing the user to publish to a new location or replace existing content. This change allows the resulting request to succeed.

Connected to #83
Connected to #72 

### Testing Notes / Validation Steps

* Publish a notebook with title "test".
* Publish it again, changing title to "test2" and selecting New Location.
* Publish it again, changing title back to "test" and selecting New Location. Publication should not fail with a duplicate name error.

