### PR TITLE
update button text sooner

### DIFF
--- a/rsconnect/static/connect.js
+++ b/rsconnect/static/connect.js
@@ -705,9 +705,11 @@ define([
         txtTitle = publishModal.find("[name=title]");
         txtTitle.val(initialTitle);
 
-        txtTitle.change(function() {
+        function updateDeployNextButton() {
           btnPublish.text("Next");
-        });
+        }
+        txtTitle.change(updateDeployNextButton);
+        txtTitle.on("keypress", updateDeployNextButton);
         maybeShowConfigUrl();
 
         txtApiKey = publishModal.find("[name=api-key]").val(userProvidedApiKey);


### PR DESCRIPTION
### Description

Address feedback from validation of #75 by changing the Deploy button title on keypress rather than waiting for the change event.

Connected to #75

### Testing Notes / Validation Steps

Publish a notebook. Go back to publish window and edit the title. The Deploy button should change text to "Next" as soon as the edit occurs rather than having to tab or click elsewhere.
