### PR TITLE
Exclude rsconnect-jupyter plugin from dependencies

### DIFF
--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -23,7 +23,7 @@ def detect_environment(dirname):
     of `pip freeze` will be used.
 
     Returns a dictionary containing the package spec filename
-    and contents if successful, or a dictionary containing 'error' 
+    and contents if successful, or a dictionary containing 'error'
     on failure.
     """
     result = (output_file(dirname, 'requirements.txt', 'pip') or
@@ -70,7 +70,7 @@ def output_file(dirname, filename, package_manager):
     """Read an existing package spec file.
 
     Returns a dictionary containing the filename and contents
-    if successful, None if the file does not exist, 
+    if successful, None if the file does not exist,
     or a dictionary containing 'error' on failure.
     """
     try:
@@ -80,6 +80,9 @@ def output_file(dirname, filename, package_manager):
 
         with open(path, 'r') as f:
             data = f.read()
+
+        data = '\n'.join([line for line in data.split('\n')
+                                if 'rsconnect-jupyter' not in line])
 
         return {
             'filename': filename,
@@ -100,7 +103,7 @@ def pip_freeze(dirname):
     """
     try:
         proc = subprocess.Popen(
-            ['pip', 'freeze'], 
+            ['pip', 'freeze'],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
 
         pip_stdout, pip_stderr = proc.communicate()
@@ -111,6 +114,9 @@ def pip_freeze(dirname):
     if pip_status != 0:
         msg = pip_stderr or ('exited with code %d' % pip_status)
         raise EnvironmentException('Error during pip freeze: %s' % msg)
+
+    pip_stdout = '\n'.join([line for line in pip_stdout.split('\n')
+                            if 'rsconnect-jupyter' not in line])
 
     return {
         'filename': 'requirements.txt',
@@ -124,7 +130,7 @@ if __name__ == '__main__':
     try:
         if len(sys.argv) < 2:
             raise EnvironmentException('Usage: %s NOTEBOOK_PATH' % sys.argv[0])
-        
+
         notebook_path = sys.argv[1]
         dirname = os.path.dirname(notebook_path)
         result = detect_environment(dirname)


### PR DESCRIPTION
### Description

Exclude `rsconnect-jupyter` plugin from dependencies.

I don't know if this is the correct fix but we need it at the moment since our python package is not publicly available.

### Testing Notes / Validation Steps