### PR TITLE
exclude rsconnect-jupyter from the generated environment spec

### DIFF
--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -112,6 +112,9 @@ def pip_freeze(dirname):
         msg = pip_stderr or ('exited with code %d' % pip_status)
         raise EnvironmentException('Error during pip freeze: %s' % msg)
 
+    # exclude rsconnect package
+    pip_stdout = '\n'.join(filter(lambda s:'rsconnect-jupyter' not in s, pip_stdout.splitlines()))
+
     return {
         'filename': 'requirements.txt',
         'contents': pip_stdout,


### PR DESCRIPTION
### Description

When introspecting the environment with `pip freeze`, pip records the presence of the rsconnect-jupyter package. Once it's publicly available, this will be ok, but currently it lives in a private git repo so the requirements.txt file contains a line like:
```
-e git+git@github.com:rstudio/rsconnect-jupyter.git@cfa6b605ea0f545f6a949835cb5f250372dbcf75#egg=rsconnect
```

In Connect, we don't support reconstructing environments that depend on packages installed from source via a private git repo; trying to do so results in an error like:
```
2018/09/22 23:38:25 2018/09/22 23:38:25.738838082   Cloning git@github.com:rstudio/rsconnect-jupyter.git (to revision 18cefeac9eb6130b2e08383eb6eeb34a76d8d749) to ./python/src/rsconnect
2018/09/22 23:38:26 2018/09/22 23:38:26.020930773 Host key verification failed.
2018/09/22 23:38:26 2018/09/22 23:38:26.021218883 fatal: Could not read from remote repository.
2018/09/22 23:38:26 2018/09/22 23:38:26.021233682 
2018/09/22 23:38:26 2018/09/22 23:38:26.021260713 Please make sure you have the correct access rights
2018/09/22 23:38:26 2018/09/22 23:38:26.021261894 and the repository exists.
2018/09/22 23:38:26 2018/09/22 23:38:26.217744717 Command "git clone -q git@github.com:rstudio/rsconnect-jupyter.git /connect/mnt/app/python/src/rsconnect" failed with error code 128 in None
2018/09/22 23:38:26 2018/09/22 23:38:26.266216494 pip install failed with exit code 1
2018/09/22 23:38:26 Build error: exit status 1
```

So for now, we'll filter rsconnect-jupyter out of the environment.

### Testing Notes / Validation Steps
* Publish from rsconnect-jupyter using the new Python builder in Connect
* Publishing should succeed rather than failing the build step.
