### PR TITLE
Add version metadata (v1 for now)

### DIFF
--- a/rsconnect/static/connect.js
+++ b/rsconnect/static/connect.js
@@ -51,11 +51,12 @@ define([
 
   function RSConnect(c) {
     /* sample value of `Jupyter.notebook.metadata`:
-       { previousServerId: "abc-def-ghi-jkl"
+       { version: 1,
+         previousServerId: "abc-def-ghi-jkl",
          servers: {
-           "xyz-uvw": { server: "http://172.0.0.3:3939/", serverName: "dev" }
-           "rst-opq": { server: "http://somewhere/connect/", serverName: "prod", notebookTitle:"Meow", appId: 42, appMode: "static" }
-         }
+           "xyz-uvw": { server: "http://172.0.0.3:3939/", serverName: "dev" },
+           "rst-opq": { server: "http://somewhere/connect/", serverName: "prod", notebookTitle:"Meow", appId: 42, appMode: "static" },
+         },
        }
     */
 
@@ -96,6 +97,7 @@ define([
       var self = this;
       // overwrite metadata (user may have changed it)
       Jupyter.notebook.metadata.rsconnect = {
+        version: 1,
         previousServerId: self.previousServerId,
         servers: self.servers
       };


### PR DESCRIPTION
### Description

Connected to #59 

### Testing Notes / Validation Steps

Test the following with a new and existing notebook that you've published previously;

- publish a notebook
- in the notebook go to Edit -> Edit Notebook Metadata
- there should be a `version` key under `rsconnect`

e.g.
![image](https://user-images.githubusercontent.com/193628/46315262-362ede00-c58a-11e8-87c3-514861767e3f.png)
