### PR TITLE
Add setuptools and pip to install list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN conda update conda
 
 USER ${NB_UID}:${NB_GID}
 RUN bash -c 'cd /home/builder \
-    && conda create --yes --channel conda-forge --name py${PY_VERSION/./} python=${PY_VERSION} jupyter'
+    && conda create --yes --channel conda-forge --name py${PY_VERSION/./} python=${PY_VERSION} jupyter setuptools pip'


### PR DESCRIPTION
### Description

This fixes python 3.4 tests failing due to an old version of setuptools

### Testing Notes / Validation Steps
- Build passes with flying green colors