### PR TITLE
Do not explicity publish the app when it is deployed

### DIFF
--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -228,7 +228,6 @@ def deploy(uri, api_key, app_id, app_name, app_title, tarball):
             raise RSConnectException('Failed to deploy successfully')
 
         # app deployed successfully
-        api.app_publish(app['id'], 'acl')
         config = api.app_config(app['id'])
         return {
             'app_id': app['id'],


### PR DESCRIPTION
### Description

Connected to rstudio/connect#11747

The server automatically publishes this based on the
`Applications.ExplicityPublishing` setting which is `false` by default.

### Testing Notes / Validation Steps

- [x] when `Applications.ExplicityPublishing = true` document is not auto-published
- [x] when `Applications.ExplicityPublishing = false` document is auto-published