### PR TITLE
use docker image tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,7 +152,8 @@ try {
       }
       stage('Docs build') {
         docs_image = pullBuildPush(
-          image_name: 'jenkins/rsconnect-jupyter-docs',
+          image_name: 'jenkins/rsconnect-jupyter',
+          image_tag: 'docs',
           docker_context: './docs',
           push: !isUserBranch
         )


### PR DESCRIPTION
### Description

This PR is intended to fix the problem with pushing the docs docker image (#111). It will be merged immediately, since the change only affects Jenkins builds on master.

Connected to #91 
