### PR TITLE
bump version in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ source bin/activate
 Install the `rsconnect` package with the following command:
 
 ```
-pip install rsconnect-1.0.0-py2.py3-none-any.whl
+pip install rsconnect-1.1.0-py2.py3-none-any.whl
 ```
 
 Enable the `rsconnect` extension with the following commands:


### PR DESCRIPTION
### Description

The docs call out the wheel file to install. This bumps the version mentioned there from 1.0.0 to 1.1.0 (current version on master).


Connected to #115

### Testing Notes / Validation Steps
Review updated docs
