### PR TITLE
Fix button state

### DIFF
--- a/rsconnect/static/connect.js
+++ b/rsconnect/static/connect.js
@@ -812,10 +812,13 @@ define([
         txtTitle.val(initialTitle);
 
         function updateDeployNextButton() {
-          btnPublish.text("Next");
+          if (txtTitle.val() === initialTitle) {
+            btnPublish.text("Publish");
+          } else {
+            btnPublish.text("Next");
+          }
         }
-        txtTitle.change(updateDeployNextButton);
-        txtTitle.on("keypress", updateDeployNextButton);
+        txtTitle.on("input", updateDeployNextButton);
         maybeShowConfigUrl();
 
         txtApiKey = publishModal.find("[name=api-key]").val(userProvidedApiKey);


### PR DESCRIPTION
### Description

This PR changes how the call to appSearch updates the Publish button state.

Previously, it always re-enabled the button after appSearch completed. This contributed to the issues reported in #118. The new behavior is for appSearch only to re-enable the button on failure; on success, we will proceed to either publishing, or to the destination selection (search results) dialog.

Connected to #118

### Testing Notes / Validation Steps
* Publish a new notebook
* The Publish button should be grayed out and the spinner present during publishing.

Also try the other cases to ensure this hasn't broken anything:
* Republish to the same app
* Change the title and publish to a new location
* Change the title and replace a matching app
* Republish to a deleted app
