### PR TITLE
Fix button state

### DIFF
--- a/rsconnect/static/connect.js
+++ b/rsconnect/static/connect.js
@@ -812,7 +812,7 @@ define([
         txtTitle.val(initialTitle);
 
         function updateDeployNextButton() {
-          lastPublishedTitle =
+          var lastPublishedTitle =
             config.servers &&
             config.servers[selectedEntryId] &&
             config.servers[selectedEntryId].notebookTitle;


### PR DESCRIPTION
### Description

Change the basis of comparison for detecting title changes, to handle the case of returning from a secondary dialog (search).

Connected to #98

### Testing Notes / Validation Steps
* Publish notebook (example title: "title")
* Open publish dialog. Change title (e.g. to "title1"), see button change to Next. Click Next.
* Search dialog is displayed; cancel it.
* When you're returned to Publish dialog, verify button state. Title should be "title1" and button should say "Next".
* Change title back to what it was ("title"). Button should change to "Publish".
* Change to "title2" and publish (by clicking Next and selecting New Location).
* Reopen publishing dialog. Title should be "title2" and changes from there should result in button changing to Next.


