### PR TITLE
Jupyterhub support

### DIFF
--- a/rsconnect/static/connect.js
+++ b/rsconnect/static/connect.js
@@ -120,7 +120,7 @@ define([
 
     verifyServer: function(server) {
       return Utils.ajax({
-        url: "/rsconnect_jupyter/verify_server",
+        url: Jupyter.notebook.base_url + "rsconnect_jupyter/verify_server",
         method: "POST",
         headers: { "Content-Type": "application/json" },
         data: JSON.stringify({
@@ -155,7 +155,7 @@ define([
       var entry = this.servers[serverId];
 
       return Utils.ajax({
-        url: "/rsconnect_jupyter/app_get",
+        url: Jupyter.notebook.base_url + "rsconnect_jupyter/app_get",
         method: "POST",
         headers: { "Content-Type": "application/json" },
         data: JSON.stringify({
@@ -181,7 +181,7 @@ define([
       }
       debug.info("saving config:", toSave);
       return Utils.ajax({
-        url: "/api/config/rsconnect_jupyter",
+        url: Jupyter.notebook.base_url + "api/config/rsconnect_jupyter",
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         data: JSON.stringify(toSave)
@@ -194,7 +194,7 @@ define([
       };
 
       return Utils.ajax({
-        url: "/rsconnect_jupyter/get_api_key",
+        url: Jupyter.notebook.base_url + "rsconnect_jupyter/get_api_key",
         method: "POST",
         headers: { "Content-Type": "application/json" },
         data: JSON.stringify(data)
@@ -208,7 +208,7 @@ define([
       };
 
       return Utils.ajax({
-        url: "/rsconnect_jupyter/set_api_key",
+        url: Jupyter.notebook.base_url + "rsconnect_jupyter/set_api_key",
         method: "POST",
         headers: { "Content-Type": "application/json" },
         data: JSON.stringify(data)
@@ -218,7 +218,7 @@ define([
     fetchConfig: function() {
       var self = this;
       return Utils.ajax({
-        url: "/api/config/rsconnect_jupyter",
+        url: Jupyter.notebook.base_url + "api/config/rsconnect_jupyter",
         method: "GET"
       }).then(function(data) {
         debug.info("fetched config:", data);
@@ -306,7 +306,7 @@ define([
         };
 
         var xhr = Utils.ajax({
-          url: "/rsconnect_jupyter/deploy",
+          url: Jupyter.notebook.base_url + "rsconnect_jupyter/deploy",
           method: "POST",
           headers: { "Content-Type": "application/json" },
           data: JSON.stringify(data)
@@ -339,7 +339,7 @@ define([
       var entry = this.servers[serverId];
 
       return Utils.ajax({
-        url: "/rsconnect_jupyter/app_search",
+        url: Jupyter.notebook.base_url + "rsconnect_jupyter/app_search",
         method: "POST",
         headers: { "Content-Type": "application/json" },
         data: JSON.stringify({


### PR DESCRIPTION
### Description

This PR enables Jupyterhub support. The plugin already loads successfully in Jupyterhub, but we're required to add Jupyter.notebook.base_url to all of our ajax calls. (This would also enable compatibility with proxied Jupyter installations that run Jupyter on a path other than `/`').

Connected to https://github.com/rstudio/connect/issues/10129 

### Testing Notes / Validation Steps
Docs for how to use this with Jupyterhub will be in a separate PR. For now, put this Dockerfile:

```
FROM jupyterhub/jupyterhub

# Install Jupyter notebook into the existing base conda environment
RUN conda install notebook

# Download and install the plugin in the same environment
ARG FILENAME

COPY ${FILENAME} /tmp/${FILENAME}
RUN pip install /tmp/${FILENAME} && \
	jupyter-nbextension install --sys-prefix --py rsconnect && \
	jupyter-nbextension enable --sys-prefix --py rsconnect && \
	jupyter-serverextension enable --sys-prefix --py rsconnect

RUN jupyterhub --generate-config

# create test users
RUN useradd -m -s /bin/bash user1 && \
	useradd -m -s /bin/bash user2 && \
	useradd -m -s /bin/bash user3 && \
	bash -c 'echo -en "password\npassword" | passwd user1' && \
	bash -c 'echo -en "password\npassword" | passwd user2' && \
	bash -c 'echo -en "password\npassword" | passwd user3'

CMD ["jupyterhub"]
```

and this script:
```
#!/usr/bin/env bash

set -e

RSCONNECT_VERSION=1.1.0.9999
FILENAME=rsconnect-${RSCONNECT_VERSION}-py2.py3-none-any.whl

docker build --build-arg FILENAME=${FILENAME} -t jupyterhub:rsconnect .
docker run --rm -p 8000:8000 --name jupyterhub jupyterhub:rsconnect
```

in a directory along with the wheel file output from `make dist`.

* Run the script to build the docker image and start up Jupyterhub. 
* Connect to http://localhost:8000
* Log in as `user1` with `password`; you should be able to create and publish notebooks. 
* Log in as `user2` and do the same, to ensure that all users have access to the plugin.

Note that the default Jupyterhub has python 3.6.5; you will need a compatible Python on the Connect server in order to publish with source.
