### PR TITLE
Jupyterhub docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -168,8 +168,6 @@ RUN pip install rsconnect-${RSCONNECT_VERSION}-py2.py3-none-any.whl && \
 	jupyter-nbextension enable --sys-prefix --py rsconnect && \
 	jupyter-serverextension enable --sys-prefix --py rsconnect
 
-RUN jupyterhub --generate-config
-
 # create test users
 RUN useradd -m -s /bin/bash user1 && \
 	useradd -m -s /bin/bash user2 && \


### PR DESCRIPTION
### Description

This PR introduces a new section documenting how to install the plugin in Jupyterhub, along with a working example.

Connected to rstudio/connect#10129

### Testing Notes / Validation Steps
Follow the instructions in the doc to configure and test Jupyterhub
