### PR TITLE
Fix version number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ endif
 ## Inside Jenkins (when JOB_NAME is defined), we are in the right type of
 ## Docker container. Otherwise, launch pandoc inside a
 ## rstudio/connect:docs container.
-BUILD_DOC=./docs/build-doc.sh
+BUILD_DOC=env VERSION=${VERSION} ./docs/build-doc.sh
 ifeq (${JOB_NAME},)
 	BUILD_DOC=docker run --rm=true ${DOCKER_RUN_AS} \
 		-e VERSION=${VERSION} \

--- a/docs/build-doc.sh
+++ b/docs/build-doc.sh
@@ -2,7 +2,6 @@
 
 set -ex
 
-mkdir -p dist/html
 cd docs/guide
 
 pandoc -f markdown-implicit_figures \


### PR DESCRIPTION
### Description

Pass `VERSION` env var to docs-build so docs are labeled correctly. A previous doc-related PR broke this (probably me :slightly_frowning_face:).

### Testing Notes / Validation Steps
- [ ] html and pdf docs are versioned

e.g.
![image](https://user-images.githubusercontent.com/193628/48382086-a4dc7c80-e69c-11e8-81a3-7a9a76efcedf.png)