### PR TITLE
Ensure content-type is set for json response

### DIFF
--- a/mock_connect.py
+++ b/mock_connect.py
@@ -100,7 +100,7 @@ def authenticated(f):
 def json(f):
     @wraps(f)
     def wrapper(*args, **kw):
-        return jsonify(dumps(f(*args, **kw), indent=4, sort_keys=True))
+        return jsonify(f(*args, **kw))
     return wrapper
 
 def item_by_id(d):


### PR DESCRIPTION
### Description

Connected to #122 

This updates the mock server so json responses contain the correct `Content-Type` header.  This enables selenium tests to pass. (Changes reflect those made in #122 to check for json response via `Content-Type` header)

### Testing Notes / Validation Steps
- [ ] selenium tests pass