### PR TITLE
use sys.executable instead of sys.exec_prefix

### DIFF
--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -8,7 +8,7 @@ import sys
 
 
 version_re = re.compile(r'\d+\.\d+(\.\d+)?')
-exec_dir = os.path.join(sys.exec_prefix, 'bin')
+exec_dir = os.path.dirname(sys.executable)
 
 
 class EnvironmentException(Exception):


### PR DESCRIPTION
### Description

The environment detection fails to find pip when using Homebrew python on Mac. This is because sys.exec_prefix/bin doesn't contain the pip binary; it's colocated with the symlink to the python binary (pointed to by sys.executable).

```
$ /usr/local/bin/python environment.py .
{
    "error": "Error getting 'pip' version: File not found: /usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/bin/pip"
}
```

### Testing Notes / Validation Steps
* Install python with homebrew on Mac. Run `/usr/local/bin/python environment.py .` Verify that pip is found and a normal JSON output (no errors) results.
* Regression check: run unit tests, which use anaconda python on linux (make test2 test3)
