### PR TITLE
Fix Sean's findings :)

### DIFF
--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -254,7 +254,10 @@ def deploy(uri, api_key, app_id, app_name, app_title, tarball):
 
         if task['code'] != 0:
             # app failed to deploy
-            raise RSConnectException('Failed to deploy successfully')
+            err_msg = 'Failed to deploy successfully'
+            if 'error' in task:
+                err_msg += ': ' + task['error']
+            raise RSConnectException(err_msg)
 
         # app deployed successfully
         config = api.app_config(app['id'])

--- a/rsconnect/static/connect.js
+++ b/rsconnect/static/connect.js
@@ -914,7 +914,7 @@ define([
             addValidationMarkup(
               false,
               txtTitle,
-              "Failed to publish. " + xhr.responseJSON.message
+              xhr.responseJSON.message
             );
             togglePublishButton(true);
           }


### PR DESCRIPTION
### Description

Connected to #137 

### Testing Notes / Validation Steps

Launch jupyter-notebook in jupyterhub (docs - http://docs.rstudio.com/rsconnect-jupyter/#installation-in-jupyterhub):

- [x] images are visible in publish dialog
- [x] able to publish notebook with source when Connect does not have a binary named `python` (it can be `python2` or `python3` [anything really])
- [x] more detailed error message on publish w/source failure - e.g. try to deploy a 3.7.1 notebook to Connect which only has 2.x.  You should see something like the following:

![image](https://user-images.githubusercontent.com/193628/49389830-7c1c3580-f6e4-11e8-90c0-b4ec64092e6e.png)
