### PR TITLE
Fix artifact names in docs pipeline

### DIFF
--- a/doc.Jenkinsfile
+++ b/doc.Jenkinsfile
@@ -24,8 +24,8 @@ pipeline {
                 }
             }
             steps {
-                sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect-jupyter-${RELEASE_VERSION}.html s3://docs.rstudio.com/rsconnect-jupyter/ --dryrun"
-                sh "aws s3 cp s3://docs.rstudio.com/rsconnect-jupyter/rsconnect-jupyter-${RELEASE_VERSION}.html s3://docs.rstudio.com/rsconnect-jupyter/index.html --dryrun"
+                sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}.html s3://docs.rstudio.com/rsconnect-jupyter/ --dryrun"
+                sh "aws s3 cp s3://docs.rstudio.com/rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}.html s3://docs.rstudio.com/rsconnect-jupyter/index.html --dryrun"
             }
         }
         stage('Promote Docs') {
@@ -36,8 +36,8 @@ pipeline {
                 }
             }
             steps {
-                sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect-jupyter-${RELEASE_VERSION}.html s3://docs.rstudio.com/rsconnect-jupyter/"
-                sh "aws s3 cp s3://docs.rstudio.com/rsconnect-jupyter/rsconnect-jupyter-${RELEASE_VERSION}.html s3://docs.rstudio.com/rsconnect-jupyter/index.html"
+                sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}.html s3://docs.rstudio.com/rsconnect-jupyter/"
+                sh "aws s3 cp s3://docs.rstudio.com/rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}.html s3://docs.rstudio.com/rsconnect-jupyter/index.html"
             }
         }
     }


### PR DESCRIPTION
### Description
Our artifacts now have an underscore instead of a hyphen between `rsconnect` and `jupyter`. I forgot to update this earlier.

### Testing Notes / Validation Steps
- ensure that docs are promoted w/o build failure