### PR TITLE
Remove requirements.txt support

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -131,16 +131,9 @@ kernel environment; that is, the environment where the `ipykernel` package is
 installed. In most cases that will be the same as the notebook server
 environment where `jupyter` is installed.
 
-If there is a `requirements.txt` file in the same directory as the notebook
-file, its contents will be used. This allows you to directly control which
-packages will be installed on the RStudio Connect server before the notebook is
-rendered. If you use this option, you must ensure that all necessary packages
-are listed in the `requirements.txt` file.
-
-If there isn't a requirements file, the command `pip freeze` will be used to
-inspect the environment. The output of `pip freeze` lists all packages currently
-installed, as well as their versions, which enables RStudio Connect to recreate
-the same environment.
+The command `pip freeze` will be used to inspect the environment. The output
+of `pip freeze` lists all packages currently installed, as well as their
+versions, which enables RStudio Connect to recreate the same environment.
 
 
 ### Handling conflicts

--- a/rsconnect_jupyter/environment.py
+++ b/rsconnect_jupyter/environment.py
@@ -115,7 +115,7 @@ def pip_freeze():
         raise EnvironmentException('Error during pip freeze: %s' % msg)
 
     pip_stdout = '\n'.join([line for line in pip_stdout.split('\n')
-                            if 'rsconnect-jupyter' not in line])
+                            if 'rsconnect' not in line])
 
     return {
         'filename': 'requirements.txt',

--- a/rsconnect_jupyter/environment.py
+++ b/rsconnect_jupyter/environment.py
@@ -18,9 +18,7 @@ class EnvironmentException(Exception):
 def detect_environment():
     """Determine the python dependencies in the environment.
 
-    If requirements.txt exists in the notebook directory,
-    its contents will be used. Otherwise, the results
-    of `pip freeze` will be used.
+    `pip freeze` will be used to introspect the environment.
 
     Returns a dictionary containing the package spec filename
     and contents if successful, or a dictionary containing 'error'

--- a/rsconnect_jupyter/environment.py
+++ b/rsconnect_jupyter/environment.py
@@ -80,9 +80,8 @@ def output_file(dirname, filename, package_manager):
         with open(path, 'r') as f:
             data = f.read()
 
-        # TODO TODO TODO TODO
         data = '\n'.join([line for line in data.split('\n')
-                                if 'rsconnect_jupyter' not in line])
+                                if 'rsconnect' not in line])
 
         return {
             'filename': filename,

--- a/rsconnect_jupyter/environment.py
+++ b/rsconnect_jupyter/environment.py
@@ -15,7 +15,7 @@ class EnvironmentException(Exception):
     pass
 
 
-def detect_environment(dirname):
+def detect_environment():
     """Determine the python dependencies in the environment.
 
     If requirements.txt exists in the notebook directory,
@@ -26,8 +26,7 @@ def detect_environment(dirname):
     and contents if successful, or a dictionary containing 'error'
     on failure.
     """
-    result = (output_file(dirname, 'requirements.txt', 'pip') or
-              pip_freeze(dirname))
+    result = pip_freeze()
 
     if result is not None:
         result['python'] = get_python_version()
@@ -95,7 +94,7 @@ def output_file(dirname, filename, package_manager):
         raise EnvironmentException('Error reading %s: %s' % (filename, str(exc)))
 
 
-def pip_freeze(dirname):
+def pip_freeze():
     """Inspect the environment using `pip freeze`.
 
     Returns a dictionary containing the filename
@@ -129,12 +128,7 @@ def pip_freeze(dirname):
 
 if __name__ == '__main__':
     try:
-        if len(sys.argv) < 2:
-            raise EnvironmentException('Usage: %s NOTEBOOK_PATH' % sys.argv[0])
-
-        notebook_path = sys.argv[1]
-        dirname = os.path.dirname(notebook_path)
-        result = detect_environment(dirname)
+        result = detect_environment()
     except EnvironmentException as exc:
         result = dict(error=str(exc))
 

--- a/rsconnect_jupyter/tests/test_bundle.py
+++ b/rsconnect_jupyter/tests/test_bundle.py
@@ -40,7 +40,7 @@ class TestBundle(TestCase):
         # the test environment. Don't do this in the production code, which
         # runs in the notebook server. We need the introspection to run in
         # the kernel environment and not the notebook server environment.
-        environment = detect_environment(dir)
+        environment = detect_environment()
         notebook = self.read_notebook(nb_path)
         with make_source_bundle(notebook, environment, dir) as bundle, \
             tarfile.open(mode='r:gz', fileobj=bundle) as tar:
@@ -53,9 +53,15 @@ class TestBundle(TestCase):
             ])
 
             reqs = tar.extractfile('requirements.txt').read()
-            self.assertEqual(reqs, b'numpy\npandas\nmatplotlib\n')
+
+            # these are the dependencies declared in our setup.py
+            self.assertIn(b'notebook', reqs)
+            self.assertIn(b'nbformat', reqs)
 
             manifest = json.loads(tar.extractfile('manifest.json').read().decode('utf-8'))
+
+            # don't check requirements.txt since we don't know the checksum
+            del manifest['files']['requirements.txt']
 
             # don't check locale value, just require it be present
             del manifest['locale']
@@ -77,9 +83,6 @@ class TestBundle(TestCase):
                 u"files": {
                     u"dummy.ipynb": {
                         u"checksum": u"36873800b48ca5ab54760d60ba06703a"
-                    },
-                    u"requirements.txt": {
-                        u"checksum": u"5f2a5e862fe7afe3def4a57bb5cfb214"
                     }
                 }
             })
@@ -93,7 +96,7 @@ class TestBundle(TestCase):
         # the test environment. Don't do this in the production code, which
         # runs in the notebook server. We need the introspection to run in
         # the kernel environment and not the notebook server environment.
-        environment = detect_environment(dir)
+        environment = detect_environment()
         notebook = self.read_notebook(nb_path)
 
         with make_source_bundle(notebook, environment, dir, extra_files=['data.csv']) as bundle, \
@@ -159,7 +162,7 @@ class TestBundle(TestCase):
         # the test environment. Don't do this in the production code, which
         # runs in the notebook server. We need the introspection to run in
         # the kernel environment and not the notebook server environment.
-        environment = detect_environment(dir)
+        environment = detect_environment()
         notebook = self.read_notebook(nb_path)
 
         # borrowed these from the running notebook server in the container

--- a/rsconnect_jupyter/tests/test_environment.py
+++ b/rsconnect_jupyter/tests/test_environment.py
@@ -17,26 +17,8 @@ class TestEnvironment(TestCase):
     def python_version(self):
     	return '.'.join(map(str, sys.version_info[:3]))
 
-    def test_file(self):
-        result = detect_environment(self.get_dir('pip1'))
-
-        pip_version = result.pop('pip')
-        self.assertTrue(version_re.match(pip_version))
-
-        locale = result.pop('locale')
-        self.assertIsInstance(locale, str)
-        self.assertIn('.', locale)
-
-        self.assertEqual(result, {
-            'package_manager': 'pip',
-            'source': 'file',
-            'filename': 'requirements.txt',
-            'contents': 'numpy\npandas\nmatplotlib\n',
-            'python': self.python_version(),
-        })
-
     def test_pip_freeze(self):
-        result = detect_environment(self.get_dir('pip2'))
+        result = detect_environment()
         contents = result.pop('contents')
 
         # these are the dependencies declared in our setup.py


### PR DESCRIPTION
### Description
Connected to #153 

### Testing Notes / Validation Steps
In a virtualenv containing numpy, create a notebook that requires numpy. In the same directory, create an empty requirements.txt file. Publish the notebook. It should succeed, since rsconnect-jupyter will introspect the virtualenv and include numpy in the bundle.
