### PR TITLE
PyPI release support - first cut

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,8 +139,8 @@ try {
             img.inside("-v ${env.WORKSPACE}:/rsconnect_jupyter") {
               print "building python wheel package"
               sh 'make dist'
-              archiveArtifacts artifacts: 'dist/*.whl'
-              stash includes: 'dist/*.whl', name: 'wheel'
+              archiveArtifacts artifacts: 'dist/*.whl,dist/*.tar.gz'
+              stash includes: 'dist/*.whl,dist/*.tar.gz', name: 'wheel'
             }
           },
           'python3.7': {

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean all-images image% launch notebook% package dist run test all-tests test% shell shell% dist-run dist-run% mock-server docs-build docs-image
+.PHONY: clean all-images image% launch notebook% package dist run test all-tests test% shell shell% dist-run dist-run% pypi-run pypi-run% mock-server docs-build docs-image
 
 NB_UID=$(shell id -u)
 NB_GID=$(shell id -g)
@@ -28,6 +28,7 @@ launch:
 		-e NB_UID=$(NB_UID) \
 		-e NB_GID=$(NB_GID) \
 		-e PY_VERSION=$(PY_VERSION) \
+		-e BUILD_NUMBER=$(BUILD_NUMBER) \
 		-p :9999:9999 \
 		$(DOCKER_IMAGE) \
 		/rsconnect_jupyter/run.sh $(TARGET)
@@ -83,6 +84,26 @@ dist-run%:
 
 dist-run: dist
 	pip install dist/rsconnect_jupyter-$(VERSION)-py2.py3-none-any.whl
+	jupyter-nbextension install --symlink --user --py rsconnect_jupyter
+	jupyter-nbextension enable --py rsconnect_jupyter
+	jupyter-serverextension enable --py rsconnect_jupyter
+	jupyter-notebook -y --notebook-dir=/notebooks --ip='0.0.0.0' --port=9999 --no-browser --NotebookApp.token=''
+
+pypi-run%:
+	make DOCKER_IMAGE=$(IMAGE)$* PY_VERSION=$* TARGET=pypi-run launch
+
+pypi-run:
+	pip install rsconnect_jupyter==$(VERSION)
+	jupyter-nbextension install --symlink --user --py rsconnect_jupyter
+	jupyter-nbextension enable --py rsconnect_jupyter
+	jupyter-serverextension enable --py rsconnect_jupyter
+	jupyter-notebook -y --notebook-dir=/notebooks --ip='0.0.0.0' --port=9999 --no-browser --NotebookApp.token=''
+
+pypi-test-run%:
+	make DOCKER_IMAGE=$(IMAGE)$* PY_VERSION=$* TARGET=pypi-test-run launch
+
+pypi-test-run:
+	pip install --index-url https://test.pypi.org/simple/ rsconnect_jupyter==$(VERSION)
 	jupyter-nbextension install --symlink --user --py rsconnect_jupyter
 	jupyter-nbextension enable --py rsconnect_jupyter
 	jupyter-serverextension enable --py rsconnect_jupyter

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test-selenium:
 dist:
 # wheels don't get built if _any_ file it tries to touch has a timestamp < 1980
 # (system files) so use the current timestamp as a point of reference instead
-	SOURCE_DATE_EPOCH="$(shell date +%s)"; python setup.py bdist_wheel
+	SOURCE_DATE_EPOCH="$(shell date +%s)"; python setup.py sdist bdist_wheel
 
 package:
 	make DOCKER_IMAGE=$(IMAGE)3 PY_VERSION=3 TARGET=dist launch

--- a/doc.Jenkinsfile
+++ b/doc.Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
     parameters {
         string(name: 'RELEASE_VERSION', description: 'The release version (maj.min.patch.build) to promote.')
         booleanParam(name: 'S3_SYNC', description: 'When checked, push artifacts to S3')
+        booleanParam(name: 'PYPI_RELEASE', description: 'When checked, push the wheel and sdist to PyPI')
     }
     stages {
         stage('Check Parameters') {

--- a/doc.Jenkinsfile
+++ b/doc.Jenkinsfile
@@ -40,5 +40,28 @@ pipeline {
                 sh "aws s3 cp s3://docs.rstudio.com/rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}.html s3://docs.rstudio.com/rsconnect-jupyter/index.html"
             }
         }
+        stage('Release plugin to PyPI') {
+            when {
+                allOf {
+                    expression { return params.PYPI_RELEASE }
+                    expression { return params.RELEASE_VERSION != "" }
+                }
+            }
+            environment {
+                PYPI_CREDS = credentials('pypi')
+            }
+            steps {
+                sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}-py2.py3-none-any.whl ."
+                sh "aws s3 cp s3://docs.rstudio.com/rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}.tar.gz ."
+                sh "python3 -m pip install --user twine"
+                sh """python3 -m twine upload \
+                    --repository-url https://test.pypi.org/legacy/ \
+                    -u ${PYPI_CREDS_USR} \
+                    -p ${PYPI_CREDS_PSW} \
+                    rsconnect_jupyter-${RELEASE_VERSION}-py2.py3-none-any.whl \
+                    rsconnect_jupyter-${RELEASE_VERSION}.tar.gz \
+                """
+            }
+        }
     }
 }


### PR DESCRIPTION
### Description
This PR introduces changes to the Makefile and Jenkins configuration to allow publishing to PyPI.

Connected to #157

### Testing Notes / Validation Steps
Once this PR is merged, we can try doing a PyPI release with it.
* Run the Jenkins `rsconnect-jupyter-doc-pipeline`. Set PYPI_RELEASE to false and set RELEASE_VERSION to the version/build you want to release. The package should be uploaded to test.pypi.org. Verify this by running `python3 -m pip install --index-url https://test.pypi.org/simple/ rsconnect_jupyter==version_you_want_to_test`.
* Run the Jenkins `rsconnect-jupyter-doc-pipeline`. Set PYPI_RELEASE to true and set RELEASE_VERSION to the version/build you want to release. The package should be released to the official PyPI. Verify this by running `python3 -m pip install rsconnect_jupyter==version_you_want_to_test`.

