### PR TITLE
fix docs dryrun failure

### DIFF
--- a/doc.Jenkinsfile
+++ b/doc.Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
             }
             steps {
                 sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}.html s3://docs.rstudio.com/rsconnect-jupyter/ --dryrun"
-                sh "aws s3 cp s3://docs.rstudio.com/rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}.html s3://docs.rstudio.com/rsconnect-jupyter/index.html --dryrun"
+                sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}.html s3://docs.rstudio.com/rsconnect-jupyter/index.html --dryrun"
             }
         }
         stage('Promote Docs') {
@@ -38,7 +38,7 @@ pipeline {
             }
             steps {
                 sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}.html s3://docs.rstudio.com/rsconnect-jupyter/"
-                sh "aws s3 cp s3://docs.rstudio.com/rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}.html s3://docs.rstudio.com/rsconnect-jupyter/index.html"
+                sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}.html s3://docs.rstudio.com/rsconnect-jupyter/index.html"
             }
         }
         stage('Release to PyPI (dry run)') {


### PR DESCRIPTION
### Description

When using the Jenkins doc pipeline in dryrun mode, it fails because we are attempting to copy from the rsconnect-jupyter bucket to our docs bucket, then from the docs bucket to the index page. The second copy fails because the source is not created in dryrun mode. This PR makes both copies from the same source.

Connected to #157

### Testing Notes / Validation Steps
Promote docs in dryrun mode.
