### PR TITLE
use python2 since python3 has no pip

### DIFF
--- a/doc.Jenkinsfile
+++ b/doc.Jenkinsfile
@@ -54,8 +54,8 @@ pipeline {
             steps {
                 sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}-py2.py3-none-any.whl ."
                 sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}.tar.gz ."
-                sh "python3 -m pip install --user twine"
-                sh """python3 -m twine upload \
+                sh "pip install --user twine"
+                sh """python -m twine upload \
                     --repository-url https://test.pypi.org/legacy/ \
                     -u ${PYPI_CREDS_USR} \
                     -p ${PYPI_CREDS_PSW} \
@@ -77,8 +77,8 @@ pipeline {
             steps {
                 sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}-py2.py3-none-any.whl ."
                 sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}.tar.gz ."
-                sh "python3 -m pip install --user twine"
-                sh """python3 -m twine upload \
+                sh "pip install --user twine"
+                sh """python -m twine upload \
                     -u ${PYPI_CREDS_USR} \
                     -p ${PYPI_CREDS_PSW} \
                     rsconnect_jupyter-${RELEASE_VERSION}-py2.py3-none-any.whl \


### PR DESCRIPTION
### Description
`python3 -m pip install` fails because pip is not installed. Twine supports python2 so switching to just using `pip install` and `python -m twine`.

Connected to #157
