### PR TITLE
update packages before building dist (wheel) too

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,6 +137,7 @@ try {
             img = buildAndTest("3.6")
 
             img.inside("-v ${env.WORKSPACE}:/rsconnect_jupyter") {
+              sh "pip install --user --upgrade twine setuptools wheel"
               print "building python wheel package"
               sh 'make dist'
               archiveArtifacts artifacts: 'dist/*.whl,dist/*.tar.gz'


### PR DESCRIPTION
### Description

We also need to update to the latest setuptools and wheel before `make dist` in order for the wheel metadata to be correct.

Connected to #157
