### PR TITLE
move title metadata out of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
----
-title: rsconnect-jupyter User Guide
----
+# rsconnect-jupyter
+
 [rsconnect-jupyter](https://www.github.com/rstudio/rsconnect-jupyter/) is a
 plugin for [Jupyter Notebook](https://jupyter.org/) that enables
 publishing notebooks to [RStudio

--- a/docs/build-doc.sh
+++ b/docs/build-doc.sh
@@ -2,12 +2,18 @@
 
 set -ex
 
+TITLE='rsconnect-jupyter User Guide'
+
 pandoc -f markdown-implicit_figures \
     --self-contained \
     -o dist/rsconnect_jupyter-${VERSION}.html \
     -H docs/images/style.css \
+    -T "${TITLE}" \
+    -M "title:${TITLE}" \
     README.md
 
 pandoc -f markdown-implicit_figures \
     -o dist/rsconnect_jupyter-${VERSION}.pdf \
+    -T "${TITLE}" \
+    -M "title:${TITLE}" \
     README.md


### PR DESCRIPTION
### Description

Have successfully used dry-run mode so the next step is to actually post to PyPI. This PR tweaks the appearance of the README to eliminate the "title: rsconnect-jupyter User Guide" that appears at the top of the readme on PyPI.

Connected to #157
