### PR TITLE
show deployment failure message, if any

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,9 +127,6 @@ try {
           'python2.7': {
             buildAndTest("2.7")
           },
-          'python3.4': {
-            img = buildAndTest("3.4")
-          },
           'python3.5': {
             img = buildAndTest("3.5")
           },

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -305,6 +305,8 @@ define([
 
       var $log = $("#rsc-log").attr("hidden", null);
       $log.text("Deploying...\n");
+      var $deploy_err = $("#rsc-deploy-error");
+      $deploy_err.text("");
 
       function getLogs(deployResult) {
         function inner(lastStatus) {
@@ -329,9 +331,9 @@ define([
             }
             if (result["finished"]) {
               if (result["code"] != 0) {
-                return $.Deferred().reject(
-                  "Failed to deploy successfully: " + result["error"]
-                );
+                var msg = "Failed to deploy successfully: " + result["error"];
+                addValidationMarkup(false, $deploy_err, msg)
+                return $.Deferred().reject(msg);
               }
               debug.info("logs:", result["status"].join("\n"));
               return $.Deferred().resolve(deployResult["app_id"]);
@@ -850,6 +852,9 @@ define([
         "        </div>",
         "    </div>",
         '    <pre id="rsc-log" hidden></pre>',
+        '    <div class="form-group">',
+        '    <span id="rsc-deploy-error" class="help-block"></span>',
+        '    </div>',
         '    <div class="text-center" data-id="configUrl"></div>',
         '    <input type="submit" hidden>',
         "</form>"

--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,6 @@ setup(name='rsconnect_jupyter',
           'nbconvert>=5.0',
           'six'
       ] + ipython_dependency,
+      python_requires = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
       include_package_data=True,
       zip_safe=False)


### PR DESCRIPTION
### Description

If notebook rendering fails, display the error on the plugin UI.

Connected to https://github.com/rstudio/connect/issues/15131 

### Testing Notes / Validation Steps
Deploy to a Connect instance that doesn't have a matching version of python installed. The error should be displayed in red below the build log. (Note, a similar or identical error may also be in the build log depending on the type of failure).
