### PR TITLE
pass cookies from deploy API call back into task_get

### DIFF
--- a/rsconnect_jupyter/__init__.py
+++ b/rsconnect_jupyter/__init__.py
@@ -164,8 +164,10 @@ class EndpointHandler(APIHandler):
             api_key = data['api_key']
             task_id = data['task_id']
             last_status = data['last_status']
+            cookies = data.get('cookies', [])
+
             try:
-                retval = task_get(uri, api_key, task_id, last_status)
+                retval = task_get(uri, api_key, task_id, last_status, cookies)
             except RSConnectException as exc:
                 raise web.HTTPError(400, exc.message)
             self.finish(json.dumps(retval))

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -319,7 +319,8 @@ define([
               server_address: entry.server,
               api_key: apiKey,
               task_id: deployResult["task_id"],
-              last_status: lastStatus
+              last_status: lastStatus,
+              cookies: deployResult.cookies || []
             })
           }).then(function(result) {
             if (result["last_status"] != lastStatus) {


### PR DESCRIPTION
### Description

This PR captures cookies returned from the deploy call, and passes them back into the task status call. This is needed for HA configurations, where cookies are used to provide sticky sessions (since task status calls must hit the same node where the content is being deployed).

This also uses the standard library SimpleCookie class to parse the Set-Cookie header. Previously we were not parsing it.

Connected to #173 

### Testing Notes / Validation Steps
Deploy notebooks to an HA Connect cluster multiple times. There should be no task status call failures.
