### PR TITLE
Fix for saved servers with no API key

### DIFF
--- a/rsconnect_jupyter/static/rsconnect.js
+++ b/rsconnect_jupyter/static/rsconnect.js
@@ -173,11 +173,14 @@ define([
                     for (var serverId in data) {
                         // Split out API keys so they're not saved into the notebook metadata.
                         var entry = data[serverId];
-                        self.apiKeys[entry.server] = entry.apiKey;
-                        delete entry.apiKey
 
-                        if (!self.servers[serverId]) {
-                            self.servers[serverId] = entry;
+                        if (entry.apiKey) {
+                            self.apiKeys[entry.server] = entry.apiKey;
+                            delete entry.apiKey
+
+                            if (!self.servers[serverId]) {
+                                self.servers[serverId] = entry;
+                            }
                         }
                     }
                 });

--- a/rsconnect_jupyter/static/rsconnect.js
+++ b/rsconnect_jupyter/static/rsconnect.js
@@ -173,14 +173,11 @@ define([
                     for (var serverId in data) {
                         // Split out API keys so they're not saved into the notebook metadata.
                         var entry = data[serverId];
+                        self.apiKeys[entry.server] = entry.apiKey;
+                        delete entry.apiKey
 
-                        if (entry.apiKey) {
-                            self.apiKeys[entry.server] = entry.apiKey;
-                            delete entry.apiKey
-
-                            if (!self.servers[serverId]) {
-                                self.servers[serverId] = entry;
-                            }
+                        if (!self.servers[serverId]) {
+                            self.servers[serverId] = entry;
                         }
                     }
                 });

--- a/rsconnect_jupyter/static/rsconnect.js
+++ b/rsconnect_jupyter/static/rsconnect.js
@@ -78,7 +78,7 @@ define([
                 return result;
             },
 
-            verifyServer: function (server) {
+            verifyServer: function (server, apiKey) {
                 var self = this;
 
                 return Utils.ajax({
@@ -87,7 +87,7 @@ define([
                     headers: {'Content-Type': 'application/json'},
                     data: JSON.stringify({
                         server_address: server,
-                        api_key: self.getApiKey(server)
+                        api_key: apiKey
                     })
                 });
             },
@@ -97,15 +97,15 @@ define([
                 if (server[server.length - 1] !== '/') {
                     server += '/';
                 }
-                this.apiKeys[server] = apiKey;
 
                 // verify the server exists, then save
-                return this.verifyServer(server).then(function (data) {
+                return this.verifyServer(server, apiKey).then(function (data) {
                     var id = data.address_hash;
                     self.servers[id] = {
                         server: data.server_address,
                         serverName: serverName
                     };
+                    self.apiKeys[server] = apiKey;
                     return self
                         .saveConfig()
                         .then(self.saveNotebookMetadata)


### PR DESCRIPTION
### Description

This PR requires the user to enter an API key when selecting a server for publishing, if none was previously entered. This should be a one-time thing after installing the new version of the plugin which stores API keys differently.

Connected to #https://github.com/rstudio/connect/issues/15189

### Testing Notes / Validation Steps
Start with a Jupyter instance that has saved servers with no API key in `~/.jupyter/nbconfig/rsconnect_jupyter.json`. Bring up a notebook and open the publishing dialog. Click on one of the saved servers. The Add Server dialog should be presented and be pre-populated with the server address and nickname, but no API key. After entering the API key, the server will be selected for publishing and publishing should succeed.

If you cancel the Add Server dialog, the server will not be selected for publishing. Clicking it again will bring up the Add Server window again; you will have to enter a valid API key and click the Add Server button in order to make it the currently-selected server. After doing so, the file (`~/.jupyter/nbconfig/rsconnect_jupyter.json`) will contain the API key.

