### PR TITLE
don't call addValidationMarkup from API

### DIFF
--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -557,6 +557,8 @@ define([
           e.preventDefault();
           publishModal.find(".form-group").removeClass("has-error");
           publishModal.find(".help-block").text("");
+          var $deploy_err = $('#rsc-deploy-error');
+          $deploy_err.text('');
 
           var validTitle = txtTitle.val().length >= 3;
 
@@ -574,7 +576,7 @@ define([
           }
 
           function handleFailure(xhr) {
-            addValidationMarkup(false, txtTitle, xhr.responseJSON.message);
+            addValidationMarkup(false, $deploy_err, xhr.responseJSON.message);
             togglePublishButton(true);
           }
 

--- a/rsconnect_jupyter/static/rsconnect.js
+++ b/rsconnect_jupyter/static/rsconnect.js
@@ -283,7 +283,8 @@ define([
                             if (result['finished']) {
                                 if (result['code'] != 0) {
                                     var msg = 'Failed to deploy successfully: ' + result['error'];
-                                    addValidationMarkup(false, $deploy_err, msg);
+                                    $deploy_err.closest(".form-group").addClass("has-error");
+                                    $deploy_err.text(msg);
                                     return $.Deferred().reject(msg);
                                 }
                                 self.debug.info('logs:', result['status'].join('\n'));

--- a/rsconnect_jupyter/static/rsconnect.js
+++ b/rsconnect_jupyter/static/rsconnect.js
@@ -255,8 +255,6 @@ define([
 
                 var $log = $('#rsc-log').attr('hidden', null);
                 $log.text('Deploying...\n');
-                var $deploy_err = $('#rsc-deploy-error');
-                $deploy_err.text('');
 
                 function getLogs(deployResult) {
                     function inner(lastStatus) {
@@ -283,9 +281,7 @@ define([
                             if (result['finished']) {
                                 if (result['code'] != 0) {
                                     var msg = 'Failed to deploy successfully: ' + result['error'];
-                                    $deploy_err.closest(".form-group").addClass("has-error");
-                                    $deploy_err.text(msg);
-                                    return $.Deferred().reject(msg);
+                                    return $.Deferred().reject({responseJSON: {message: msg}});
                                 }
                                 self.debug.info('logs:', result['status'].join('\n'));
                                 return $.Deferred().resolve(deployResult['app_id']);


### PR DESCRIPTION
### Description

On task failure, the API was calling `addValidationMarkup` which is no longer in scope after the API refactor.

Connected to #15131

### Testing Notes / Validation Steps
Created a deployment failure. The error should be displayed in red on the UI beneath the log follower.
