### PR TITLE
Surface TLS errors to the jupyter plugin UI.

### DIFF
--- a/rsconnect_jupyter/__init__.py
+++ b/rsconnect_jupyter/__init__.py
@@ -71,8 +71,7 @@ class EndpointHandler(APIHandler):
                 else:
                     raise web.HTTPError(401, u'Unable to verify the provided API key')
             else:
-                print(err)
-                raise web.HTTPError(400, u'Unable to verify that the provided server is running RStudio Connect')
+                raise web.HTTPError(400, u'Unable to verify that the provided server is running RStudio Connect: %s' % err)
             return
 
         if action == 'app_search':

--- a/rsconnect_jupyter/__init__.py
+++ b/rsconnect_jupyter/__init__.py
@@ -71,7 +71,8 @@ class EndpointHandler(APIHandler):
                 else:
                     raise web.HTTPError(401, u'Unable to verify the provided API key')
             else:
-                raise web.HTTPError(400, u'Unable to verify the provided server is running RStudio Connect')
+                print(err)
+                raise web.HTTPError(400, u'Unable to verify that the provided server is running RStudio Connect')
             return
 
         if action == 'app_search':

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -84,13 +84,26 @@ define([
     });
   }
 
+    /**
+     * addValidationMarkup adds validation hints to an element
+     * @param {Boolean} valid when true, validation hints are not added
+     * @param {jQuery} $el jQuery handle for the element to add hint to
+     * @param {String} helpText String for validation message. Newlines will be transformed to HTML line breaks
+     */
   function addValidationMarkup(valid, $el, helpText) {
     if (!valid) {
-      $el
+      var helpBlock = $el
         .closest(".form-group")
         .addClass("has-error")
-        .find(".help-block")
-        .text(helpText);
+        .find(".help-block");
+      helpBlock.empty();
+      if (helpText.match(/\n/) !== null) {
+        helpText.split('\n').forEach(function(line) {
+            helpBlock.append(line+"<br />")
+        });
+      } else {
+          helpBlock.append(helpText);
+      }
     }
   }
 
@@ -230,9 +243,17 @@ define([
                 var msg;
 
                 if (xhr.status == 400) {
-                  msg = "Failed to verify RSConnect Connect is running at " +
-                    $txtServer.val() +
-                    ". Please ensure the server address is valid.";
+                  if (xhr.responseJSON) {
+                      if (xhr.responseJSON.message) {
+                          msg = xhr.responseJSON.message;
+                      } else {
+                          msg = "Server returned an unexpected response:" + xhr.responseJSON;
+                      }
+                  } else {
+                      msg = "Failed to verify that RStudio Connect is running at " +
+                          $txtServer.val() +
+                          ". Please ensure the server address is valid.";
+                  }
                 }
                 else if (xhr.status == 401) {
                   msg = "The server did not accept the API key.";


### PR DESCRIPTION
### Description

- Make it clearer what's happening when we have TLS errors- don't just send them to the jupyter log.

- Try to give some basic debugging instructions. A follow-on from this will be the option to disable TLS certificate verification.

- For good measure, surface details of other kinds of errors too. "Connection refused" is a good one.

Screenshot of attempting to access a server with self-signed certificates:

![Screen Shot 2019-09-23 at 4 27 55 PM](https://user-images.githubusercontent.com/1735264/65460161-4edd7700-de1f-11e9-9e6a-1e28d90b03c3.png)

Screenshot of attempting to access a server that's not running at all:

![Screen Shot 2019-09-23 at 4 34 49 PM](https://user-images.githubusercontent.com/1735264/65460523-17bb9580-de20-11e9-94b5-61ab908a81da.png)


### Testing Notes / Validation Steps

- Attempt to access a server with certificate issues of some kind. Self-signed certificates are good for this. A proper error should raise.
- Attempt to access a non-existent server. "Connection refused" should appear in the message.