### PR TITLE
hide outer dialog when popping up add server dialog

### DIFF
--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -352,6 +352,7 @@ define([
             selectedEntryId = id;
             var entry = config.servers[selectedEntryId];
             if (!config.getApiKey(entry.server)) {
+              publishModal.modal("hide");
               showAddServerDialog(true, selectedEntryId, entry.server, entry.serverName);
             }
 


### PR DESCRIPTION
### Description

#182 created a workflow which pops up the Add Server dialog if there's no saved API key for an existing server. That PR neglected to close the outer dialog first, resulting in multiple layers being created. This PR addresses that issue.

Connected to #rstudio/connect#15189

### Testing Notes / Validation Steps
Start with legacy servers with no API keys saved in `~/.jupyter/nbconfig/rsconnect_jupyter.json`.Open the publish dialog and select one of the servers. The Add Server dialog should pop up, prepopulated with the server name and address (but of course no API key). Cancel the dialog. Repeat a couple times. The main publishing dialog should still look normal and if you close it, it goes away the first time.
