### PR TITLE
Don't autoscroll unless already scrolled to bottom

### DIFF
--- a/rsconnect_jupyter/static/rsconnect.js
+++ b/rsconnect_jupyter/static/rsconnect.js
@@ -286,14 +286,14 @@ define([
                                 lastStatus = result['lastStatus'];
                                 var output = result['status'].join('\n');
 
-                                var elem = $log[0];
-                                var oldScroll = elem.scrollTop;
-                                var oldMaxScroll = elem.scrollHeight - elem.clientHeight;
+                                var logElem = $log.get(0);
+                                var oldScroll = logElem.scrollTop;
+                                var oldMaxScroll = logElem.scrollHeight - logElem.clientHeight;
                                 $log.text(output);
 
                                 if (oldScroll >= oldMaxScroll - 1) {
                                   // scroll to new bottom position
-                                  $log.scrollTop(elem.scrollHeight);
+                                  $log.scrollTop(logElem.scrollHeight);
                                 }
                             }
                             if (result['finished']) {

--- a/rsconnect_jupyter/static/rsconnect.js
+++ b/rsconnect_jupyter/static/rsconnect.js
@@ -285,9 +285,16 @@ define([
                             if (result['last_status'] != lastStatus) {
                                 lastStatus = result['lastStatus'];
                                 var output = result['status'].join('\n');
+
+                                var elem = $log[0];
+                                var oldScroll = elem.scrollTop;
+                                var oldMaxScroll = elem.scrollHeight - elem.clientHeight;
                                 $log.text(output);
-                                // scroll to bottom
-                                $log.scrollTop($log.get(0).scrollHeight);
+
+                                if (oldScroll >= oldMaxScroll - 1) {
+                                  // scroll to new bottom position
+                                  $log.scrollTop(elem.scrollHeight);
+                                }
                             }
                             if (result['finished']) {
                                 if (result['code'] != 0) {


### PR DESCRIPTION
### Description

This PR prevents autoscrolling of the log view while the user has scrolled up to review the log.

### Testing Notes / Validation Steps
Deploy content. Once the log starts autoscrolling, scroll back up and wait a few seconds. It should not jump back to the bottom. Then scroll to the bottom. It should resume auto-scroll (following the log).