### PR TITLE
Add option to include files

### DIFF
--- a/rsconnect_jupyter/__init__.py
+++ b/rsconnect_jupyter/__init__.py
@@ -9,7 +9,7 @@ from notebook.utils import url_path_join
 from tornado import web
 
 from .api import app_config, app_get, app_search, deploy, task_get, verify_server, verify_api_key, RSConnectException
-from .bundle import make_html_bundle, make_source_bundle
+from .bundle import list_files, make_html_bundle, make_source_bundle
 
 __version__ = '1.0.0'
 
@@ -90,6 +90,8 @@ class EndpointHandler(APIHandler):
             api_key = data['api_key']
             app_mode = data['app_mode']
             environment = data.get('environment')
+            include_files = data['include_files']
+            include_subdirs = data['include_subdirs']
 
             model = self.contents_manager.get(path=nb_path)
             if model['type'] != 'notebook':
@@ -119,7 +121,12 @@ class EndpointHandler(APIHandler):
                     raise web.HTTPError(400, 'environment is required for jupyter-static app_mode')
 
                 try:
-                    bundle = make_source_bundle(model, environment, ext_resources_dir, extra_files=[])
+                    if include_files:
+                        extra_files = list_files(ext_resources_dir, include_subdirs)
+                    else:
+                        extra_files = []
+
+                    bundle = make_source_bundle(model, environment, ext_resources_dir, extra_files)
                 except Exception as exc:
                     self.log.exception('Bundle creation failed')
                     raise web.HTTPError(500, u"Bundle creation failed: %s" % exc)

--- a/rsconnect_jupyter/bundle.py
+++ b/rsconnect_jupyter/bundle.py
@@ -3,11 +3,12 @@ import hashlib
 import io
 import json
 import logging
+import os
 import posixpath
 import tarfile
 import tempfile
 
-from os.path import join, split, splitext
+from os.path import join, relpath, split, splitext
 
 import nbformat
 from ipython_genutils import text
@@ -105,6 +106,24 @@ def bundle_add_buffer(bundle, filename, contents):
     bundle.addfile(fileinfo, buf)
     log.debug('added buffer: %s', filename)
 
+
+def list_files(base_dir, include_subdirs):
+    """List the files in the directory at path.
+
+    If include_subdirs is True, recursively list
+    files in subdirectories.
+
+    Returns an iterable of file paths relative to base_dir.
+    """
+    def walk():
+        for root, subdirs, files in os.walk(base_dir):
+            if not include_subdirs:
+                # tell walk not to traverse any subdirs
+                subdirs[:] = []
+
+            for filename in files:
+                yield relpath(join(root, filename), base_dir)
+    return list(walk())
 
 def make_source_bundle(model, environment, ext_resources_dir, extra_files=None):
     """Create a bundle containing the specified notebook and python environment.

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -472,11 +472,11 @@ define([
         "    </div>",
         '    <div class="form-group">',
         '        <label>',
-        '          <input id="include_files" name="include_files" type="checkbox">',
+        '          <input id="include-files" name="include-files" type="checkbox">',
         '          Include all files in the notebook directory',
         '        </label>',
         '        <label>',
-        '          <input id="include_subdirs" name="include_subdirs" type="checkbox" style="margin-left: 30px">',
+        '          <input id="include-subdirs" name="include-subdirs" type="checkbox" style="margin-left: 30px">',
         '          Include subdirectories',
         '        </label>',
         "    </div>",
@@ -567,9 +567,9 @@ define([
 
         function updateCheckboxStates() {
           var publishingWithSource = (appMode === 'jupyter-static');
-          var includingFiles = $('#include_files').prop('checked');
+          var $filesBox = $('#include-files');
+          var includingFiles = $filesBox.prop('checked');
 
-          var $filesBox = $('#include_files');
           $filesBox.prop('disabled', !publishingWithSource);
           if (!publishingWithSource) {
             $filesBox.prop('checked', false);
@@ -577,7 +577,7 @@ define([
           $filesBox.parent().toggleClass('rsc-text-light', !publishingWithSource);
           
           var canIncludeSubdirs = publishingWithSource && includingFiles;
-          var $subdirsBox = $('#include_subdirs');
+          var $subdirsBox = $('#include-subdirs');
           $subdirsBox.prop('disabled', !canIncludeSubdirs);
           if (!canIncludeSubdirs) {
             $subdirsBox.prop('checked', false);
@@ -587,11 +587,12 @@ define([
 
         function bindCheckbox(id) {
           // save/restore value in server settings
-          var $box = $('#' + id);
-          $box.prop('checked', config.servers[selectedEntryId][id]);
+          var entry = config.servers[selectedEntryId];
+          var $box = $('#' + id.replace('_', '-'));
+          $box.prop('checked', entry[id]);
 
           $box.on('change', function() {
-            config.servers[selectedEntryId][id] = $box.prop('checked');
+            entry[id] = $box.prop('checked');
             updateCheckboxStates();
           });
         }

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -470,6 +470,14 @@ define([
         '            <span class="help-block"></span>',
         "        </div>",
         "    </div>",
+        '    <div class="form-group">',
+        '        <input id="include-files" name="include-files" type="checkbox">',
+        '        Include all files in the notebook directory',
+        "    </div>",
+        '    <div class="form-group">',
+        '        <input id="include-subdirs" name="include-subdirs" type="checkbox">',
+        '        Include subdirectories',
+        "    </div>",
         '    <pre id="rsc-log" hidden></pre>',
         '    <div class="form-group">',
         '    <span id="rsc-deploy-error" class="help-block"></span>',
@@ -490,7 +498,7 @@ define([
 
         // clicking on links in the modal body prevents the default
         // behavior (i.e. changing location.hash)
-        publishModal.find(".modal-body").on("click", function(e) {
+        publishModal.find("a.modal-body").on("click", function(e) {
           if ($(e.target).attr("target") !== "_rsconnect") {
             e.preventDefault();
           }
@@ -621,7 +629,9 @@ define([
                 selectedEntryId,
                 appId,
                 txtTitle.val(),
-                appMode
+                appMode,
+                $('#include-files').prop('checked'),
+                $('#include-subdirs').prop('checked')
               )
               .always(function() {
                 togglePublishButton(true);

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -668,8 +668,8 @@ define([
                 appId,
                 txtTitle.val(),
                 appMode,
-                $('#include_files').prop('checked'),
-                $('#include_subdirs').prop('checked')
+                $('#include-files').prop('checked'),
+                $('#include-subdirs').prop('checked')
               )
               .always(function() {
                 togglePublishButton(true);

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -471,12 +471,14 @@ define([
         "        </div>",
         "    </div>",
         '    <div class="form-group">',
-        '        <input id="include-files" name="include-files" type="checkbox">',
-        '        Include all files in the notebook directory',
-        "    </div>",
-        '    <div class="form-group">',
-        '        <input id="include-subdirs" name="include-subdirs" type="checkbox">',
-        '        Include subdirectories',
+        '        <label>',
+        '          <input id="include_files" name="include_files" type="checkbox">',
+        '          Include all files in the notebook directory',
+        '        </label>',
+        '        <label>',
+        '          <input id="include_subdirs" name="include_subdirs" type="checkbox" style="margin-left: 30px">',
+        '          Include subdirectories',
+        '        </label>',
         "    </div>",
         '    <pre id="rsc-log" hidden></pre>',
         '    <div class="form-group">',
@@ -559,7 +561,42 @@ define([
             .addClass("active")
             .siblings()
             .removeClass("active");
+
+          updateCheckboxStates();
         });
+
+        function updateCheckboxStates() {
+          var publishingWithSource = (appMode === 'jupyter-static');
+          var includingFiles = $('#include_files').prop('checked');
+
+          var $filesBox = $('#include_files');
+          $filesBox.prop('disabled', !publishingWithSource);
+          if (!publishingWithSource) {
+            $filesBox.prop('checked', false);
+          }
+          $filesBox.parent().toggleClass('rsc-text-light', !publishingWithSource);
+          
+          var canIncludeSubdirs = publishingWithSource && includingFiles;
+          var $subdirsBox = $('#include_subdirs');
+          $subdirsBox.prop('disabled', !canIncludeSubdirs);
+          if (!canIncludeSubdirs) {
+            $subdirsBox.prop('checked', false);
+          }
+          $subdirsBox.parent().toggleClass('rsc-text-light', !canIncludeSubdirs);
+        }
+
+        function bindCheckbox(id) {
+          // save/restore value in server settings
+          var $box = $('#' + id);
+          $box.prop('checked', config.servers[selectedEntryId][id]);
+
+          $box.on('change', function() {
+            config.servers[selectedEntryId][id] = $box.prop('checked');
+            updateCheckboxStates();
+          });
+        }
+        bindCheckbox('include_files');
+        bindCheckbox('include_subdirs');
 
         // setup app mode choices help icon
         (function() {
@@ -630,8 +667,8 @@ define([
                 appId,
                 txtTitle.val(),
                 appMode,
-                $('#include-files').prop('checked'),
-                $('#include-subdirs').prop('checked')
+                $('#include_files').prop('checked'),
+                $('#include_subdirs').prop('checked')
               )
               .always(function() {
                 togglePublishButton(true);

--- a/rsconnect_jupyter/static/rsconnect.js
+++ b/rsconnect_jupyter/static/rsconnect.js
@@ -256,7 +256,7 @@ define([
                 return result;
             },
 
-            publishContent: function (serverId, appId, notebookTitle, appMode) {
+            publishContent: function (serverId, appId, notebookTitle, appMode, includeFiles, includeSubdirs) {
                 var self = this;
                 var notebookPath = Utils.encode_uri_components(
                     Jupyter.notebook.notebook_path
@@ -335,7 +335,9 @@ define([
                         server_address: entry.server,
                         api_key: self.getApiKey(entry.server),
                         app_mode: appMode,
-                        environment: environment
+                        environment: environment,
+                        include_files: includeFiles,
+                        include_subdirs: includeSubdirs
                     };
 
                     var xhr = Utils.ajax({


### PR DESCRIPTION
### Description

This PR adds options to the publishing dialog to include all files in the directory, and to include subdirectories. The options are only enabled when publishing with source. The values are saved in the notebook metadata, so if you publish the same notebook again, they will be pre-selected.

<img width="821" alt="Screen Shot 2019-09-26 at 11 41 22 AM" src="https://user-images.githubusercontent.com/2903390/65703399-b16a8900-e052-11e9-8861-d9db255b1040.png">

Connected to #https://github.com/rstudio/connect/issues/15134

### Testing Notes / Validation Steps
* Create a notebook with additional files in the notebook directory and in a subdirectory. Publish with the `Include all files` option checked. Download the bundle from Connect and verify that the files were included, but the subdirectories were not. 
* Publish with the `Include all files` and `Include subdirectories` option checked. Download the bundle from Connect and verify that the files and subdirectories were included. Also verify that the `.ipynb_checkpoints` directory created by Jupyter was excluded.
* Publish without the boxes checked, and verify that no extra files were included (just the notebook, `manifest.json`, and `requirements.txt`).
* Validate that the box value are pre-selected when you publish again, or if you are routed through the new content / overwrite content dialog.
