### PR TITLE
Trap for unknown protocol and give better advice

### DIFF
--- a/rsconnect_jupyter/__init__.py
+++ b/rsconnect_jupyter/__init__.py
@@ -57,7 +57,14 @@ class EndpointHandler(APIHandler):
 
             try:
                 canonical_address = verify_server(server_address, disable_tls_check)
-            except SSLError:
+            except SSLError as exc:
+                if exc.reason == u'UNKNOWN_PROTOCOL':
+                    raise web.HTTPError(400,
+                                        u'Received an "SSL:UNKNOWN_PROTOCOL" error when trying to connect securely ' +
+                                        u'to the RStudio Connect server.\n' +
+                                        u'* Try changing "https://" in the "Server Address" field to "http://".\n' +
+                                        u'* If the condition persists, contact your RStudio Connect server ' +
+                                        u'administrator.')
                 raise web.HTTPError(400, u'A TLS error occurred when trying to reach the RStudio Connect server.\n' +
                                     u'* Ensure that the server address you entered is correct.\n' +
                                     u'* Ensure that your Jupyter server has the proper certificates.')


### PR DESCRIPTION
### Description

- When the user tries to access an HTTP server over HTTPS, we'd present them with the generic SSL certificate verification message.
- Now, give them actionable advice for an `UNKNOWN_PROTOCOL` error

### Testing Notes / Validation Steps

Connect to an http server with https. The new error should appear.

Connect to a self-signed https server with https. The old certificate verification error should appear.