### PR TITLE
Change how we determine which python to use for environment inspection

### DIFF
--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -702,7 +702,22 @@ define([
           }
 
           function handleFailure(xhr) {
-            addValidationMarkup(false, $deploy_err, xhr.responseJSON.message);
+            var msg;
+            if (xhr.responseJSON) {
+              if(xhr.responseJSON.message) {
+                msg = xhr.responseJSON.message;
+              }
+              else {
+                msg = 'An unknown error occurred.';
+              }
+            }
+            else if(xhr.responseText) {
+              msg = xhr.responseText;
+            }
+            else {
+              msg = 'An unknown error occurred.';
+            }
+            addValidationMarkup(false, $deploy_err, msg);
             togglePublishButton(true);
           }
 


### PR DESCRIPTION
### Description

This PR changes how we determine the kernel's python executable. Previously, we used the kernelselector's information, but that often just returned `python` rather than a full path. Now we execute python code to determine `sys.executable`.

Connected to #https://github.com/rstudio/connect/issues/15329 (this is based on a support ticket).

### Testing Notes / Validation Steps
Install python and jupyter in a virtualenv. Run jupyter directly without activating the virtualenv. Publish content. Verify the python being used via the browser console log (`Using python:`) is the one running jupyter in the environment (it should match `sys.executable` in the notebook).