### PR TITLE
Simplify Add Server dialog

### DIFF
--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -136,11 +136,6 @@ define([
   function showAddServerDialog(cancelToPublishDialog, publishToServerId, inServerAddress, inServerName) {
     var dialogResult = $.Deferred();
 
-    var serverAddress = inServerAddress;
-    var apiKey = '';
-    var serverName = inServerName;
-    var disableTLSVerification = false;
-
     var serverModal;
     var $txtServer;
     var $txtServerName;
@@ -159,8 +154,8 @@ define([
       $txtApiKey = serverModal.find('#rsc-api-key');
       $checkDisableTLSCertCheck = serverModal.find('#rsc-disable-tls-cert-check');
 
-      $txtServer.val(serverAddress);
-      $txtServerName.val(serverName);
+      $txtServer.val(inServerAddress);
+      $txtServerName.val(inServerName);
 
       $checkDisableTLSCertCheck.change(onDisableTLSCertCheckChanged);
 

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -635,8 +635,8 @@ define([
         publishModal.find('#rsc-add-server').on('click', function() {
           publishModal.modal('hide');
           showAddServerDialog(config)
-            .then(function(serverId) {
-              showSelectServerDialog(serverId);
+            .then(function(selectedServerId) {
+              showSelectServerDialog(selectedServerId);
             })
             .fail(reselectPreviousServer);
         });

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -135,13 +135,13 @@ define([
     }
   }
 
-  function showAddServerDialog(config, cancelToPublishDialog, publishToServerId, inServerAddress, inServerName) {
-    var addServerDialog = new AddServerDialog(config, cancelToPublishDialog, publishToServerId, inServerAddress, inServerName);
+  function showAddServerDialog(_config, cancelToPublishDialog, publishToServerId, inServerAddress, inServerName) {
+    var addServerDialog = new AddServerDialog(_config, cancelToPublishDialog, publishToServerId, inServerAddress, inServerName);
     return addServerDialog.result();
   }
 
-  function AddServerDialog(config, cancelToPublishDialog, publishToServerId, inServerAddress, inServerName) {
-    this.config = config;
+  function AddServerDialog(_config, cancelToPublishDialog, publishToServerId, inServerAddress, inServerName) {
+    this.config = _config;
 
     this.cancelToPublishDialog = cancelToPublishDialog;
     this.publishToServerId = publishToServerId;
@@ -323,7 +323,7 @@ define([
             }
         } else {
             msg = 'Failed to verify that RStudio Connect is running at ' +
-                $txtServer.val() +
+                this.$txtServer.val() +
                 '. Please ensure the server address is valid.';
         }
       }
@@ -366,7 +366,7 @@ define([
             self.toggleAddButton(true);
           });
       }
-    },
+    }
   };
 
   function showSelectServerDialog(

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -27,7 +27,12 @@ define([
 
     // create an action that can be invoked from many places (e.g. command
     // palette, button click, keyboard shortcut, etc.)
-    var actionName = Jupyter.actions.register(
+
+    // avoid 'accessing "actions" on the global IPython/Jupyter is not recommended' warning
+    // https://github.com/jupyter/notebook/issues/2401
+    var actions = Jupyter.notebook.keyboard_manager.actions;
+
+    var actionName = actions.register(
       {
         icon: 'fa-cloud-upload',
         help: 'Publish to RStudio Connect',

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -137,6 +137,7 @@ define([
 
   function showAddServerDialog(_config, cancelToPublishDialog, publishToServerId, inServerAddress, inServerName) {
     var addServerDialog = new AddServerDialog(_config, cancelToPublishDialog, publishToServerId, inServerAddress, inServerName);
+    addServerDialog.init();
     return addServerDialog.result();
   }
 
@@ -157,8 +158,6 @@ define([
     this.$checkDisableTLSCertCheck = null;
     this.$btnAdd = null;
     this.$btnCancel = null;
-
-    this.init();
   } 
 
   AddServerDialog.prototype = {

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -141,7 +141,7 @@ define([
   function showAddServerDialog(cancelToPublishDialog, publishToServerId, inServerAddress, inServerName) {
     var dialogResult = $.Deferred();
 
-    var serverModal;
+    var dialog;
     var $txtServer;
     var $txtServerName;
     var $txtApiKey;
@@ -152,19 +152,19 @@ define([
       disableKeyboardManagerIfNeeded();
 
       // there is no _close_ event so let's improvise.
-      serverModal.on('hide.bs.modal', closeDialog);
+      dialog.on('hide.bs.modal', closeDialog);
 
-      $txtServer = serverModal.find('#rsc-server');
-      $txtServerName = serverModal.find('#rsc-servername');
-      $txtApiKey = serverModal.find('#rsc-api-key');
-      $checkDisableTLSCertCheck = serverModal.find('#rsc-disable-tls-cert-check');
+      $txtServer = dialog.find('#rsc-server');
+      $txtServerName = dialog.find('#rsc-servername');
+      $txtApiKey = dialog.find('#rsc-api-key');
+      $checkDisableTLSCertCheck = dialog.find('#rsc-disable-tls-cert-check');
 
       $txtServer.val(inServerAddress);
       $txtServerName.val(inServerName);
 
       $checkDisableTLSCertCheck.change(onDisableTLSCertCheckChanged);
 
-      var form = serverModal.find('form').on('submit', onSubmit);
+      var form = dialog.find('form').on('submit', onSubmit);
 
       // add footer buttons
       var $btnCancel = $(
@@ -176,7 +176,7 @@ define([
       $btnAdd.on('click', function() {
         form.trigger('submit');
       });
-      serverModal
+      dialog
         .find('.modal-footer')
         .append($btnCancel)
         .append($btnAdd);
@@ -242,7 +242,7 @@ define([
     }
 
     function toggleAddButton(state) {
-      serverModal.find('fieldset').attr('disabled', state ? null : true);
+      dialog.find('fieldset').attr('disabled', state ? null : true);
       $btnAdd
         .toggleClass('disabled', !state)
         .find('i.fa')
@@ -276,7 +276,7 @@ define([
 
     function onSubmit(e) {
       e.preventDefault();
-      clearValidationMessages(serverModal);
+      clearValidationMessages(dialog);
 
       if (validate()) {
         toggleAddButton(false);
@@ -290,7 +290,7 @@ define([
           )
           .then(function(serverId) {
             dialogResult.resolve(serverId);
-            serverModal.modal('hide');
+            dialog.modal('hide');
           })
           .fail(function(xhr) {
             addValidationMarkup(
@@ -305,7 +305,7 @@ define([
       }
     }
 
-    serverModal = Dialog.modal({
+    dialog = Dialog.modal({
       // pass the existing keyboard manager so all shortcuts are disabled while
       // modal is active
       keyboard_manager: Jupyter.notebook.keyboard_manager,


### PR DESCRIPTION
### Description

This PR simplifies the code for the Add Server dialog by separating out state variables and splitting up functions. There should be no change in behavior. The goal is to make this more unit-testable (this PR does not include the tests). If this works well, we can tackle the more complex publishing dialog next.

Connected to #https://github.com/rstudio/connect/issues/15053

### Testing Notes / Validation Steps
* Use the Add Server dialog. Check field validation, display of the TLS checkbox message, canceling, etc. and create error conditions like bad server address, invalid API key, http/https mismatch, etc.
* Also check the dialog operates the same if you have saved servers without API keys. When you click the server in the Publish dialog, it should open the Add Server dialog in an editing mode with the address and name prepopulated (Modify the Jupyter config store on the server at `~/.jupyter/nbconfig/rsconnect_jupyter.json`)
