### PR TITLE
Make API Key a password field

### DIFF
--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -147,7 +147,7 @@ define([
         '        </div>',
         '        <div class="form-group">',
         '            <label class="rsc-label" for="rsc-api-key">API Key</label>',
-        '            <input class="form-control" id="rsc-api-key" type="text" placeholder="API key" minlength="32" maxlength="32" required>',
+        '            <input class="form-control" id="rsc-api-key" type="password" placeholder="API key" minlength="32" maxlength="32" required>',
         '            <span class="help-block"></span>',
         '        </div>',
         '        <div class="form-group">',

--- a/rsconnect_jupyter/static/rsconnect.js
+++ b/rsconnect_jupyter/static/rsconnect.js
@@ -174,7 +174,6 @@ define([
                         disableTLSCheck: src.disableTLSCheck
                     };
                 }
-                debug.info('saving config:', toSave);
                 return Utils.ajax({
                     url: Jupyter.notebook.base_url + 'api/config/rsconnect_jupyter',
                     method: 'PUT',
@@ -189,7 +188,6 @@ define([
                     url: Jupyter.notebook.base_url + 'api/config/rsconnect_jupyter',
                     method: 'GET'
                 }).then(function (data) {
-                    debug.info('fetched config:', data);
                     if (!self.servers) {
                         self.servers = {};
                     }
@@ -204,6 +202,7 @@ define([
                             self.servers[serverId] = entry;
                         }
                     }
+                    debug.info('fetched config:', data);
                 });
             },
 


### PR DESCRIPTION
### Description

This PR changes the type of the API Key input from `text` to `password` so the API key will not be shown. Also, now that the API key is part of the config object, we need to suppress/redact log messages that log the config.

Connected to #15374

### Testing Notes / Validation Steps
Open the Add Server dialog. The API key should not be shown as you type it in.

The browser console log should not contain any API keys.
