### PR TITLE
Fix API key merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ NB_GID=$(shell id -g)
 
 IMAGE=rstudio/rsconnect-jupyter-py
 VERSION=$(shell cat version.txt).$(shell printenv BUILD_NUMBER || echo 9999)
+PORT = $(shell printenv PORT || echo 9999)
 
 clean:
 	rm -rf build/ dist/ rsconnect_jupyter.egg-info/
@@ -29,7 +30,7 @@ launch:
 		-e NB_GID=$(NB_GID) \
 		-e PY_VERSION=$(PY_VERSION) \
 		-e BUILD_NUMBER=$(BUILD_NUMBER) \
-		-p :9999:9999 \
+		-p :$(PORT):9999 \
 		$(DOCKER_IMAGE) \
 		/rsconnect_jupyter/run.sh $(TARGET)
 

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -1106,7 +1106,7 @@ define([
       .then(config.fetchConfig())
       .then(function() {
         if (Object.keys(config.servers).length === 0) {
-          showAddServerDialog(config, false).then(showSelectServerDialog);
+          showAddServerDialog(config).then(showSelectServerDialog);
         } else {
           showSelectServerDialog(config.previousServerId);
         }

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -197,7 +197,7 @@ define([
           '        </div>',
           '        <div class="form-group">',
           '            <label class="rsc-label" for="rsc-api-key">API Key</label>',
-          '            <input class="form-control" id="rsc-api-key" type="text" placeholder="API key" minlength="32" maxlength="32" required>',
+          '            <input class="form-control" id="rsc-api-key" type="password" placeholder="API key" minlength="32" maxlength="32" required>',
           '            <span class="help-block"></span>',
           '        </div>',
           '        <div class="form-group">',


### PR DESCRIPTION
### Description

This PR fixes a merge error with the Add Server Dialog changes, that caused 2 issues: the API key field being a password field was lost, and there is an extra parameter passed to the Add Server dialog which causes the default server URL to be `false`.

There's also a Makefile change here to support testing multiple python versions at once. Previously, the notebook always mapped to localhost port 9999 so you could only run a single container. Now you can use `PORT=9998 make notebook3.5` for example to use a different port.

Connected to #15374

### Testing Notes / Validation Steps
Test out the Add Server dialog. The API key field should be a password input. The default server URL should be empty.
