### PR TITLE
Don't overwrite manifest.json

### DIFF
--- a/rsconnect_jupyter/bundle.py
+++ b/rsconnect_jupyter/bundle.py
@@ -118,12 +118,16 @@ def write_manifest(nb_name, environment, output_dir):
     manifest_filename = 'manifest.json'
     manifest = make_source_manifest(nb_name, environment, 'jupyter-static')
     manifest_file = join(output_dir, manifest_filename)
-    created = [manifest_filename]
+    created = []
     skipped = []
     
-    with open(manifest_file, 'w') as f:
-        f.write(json.dumps(manifest, indent=2))
-        log.debug('wrote manifest file: %s', manifest_file)
+    if exists(manifest_file):
+        skipped.append(manifest_filename)
+    else:
+        with open(manifest_file, 'w') as f:
+            f.write(json.dumps(manifest, indent=2))
+            created.append(manifest_filename)
+            log.debug('wrote manifest file: %s', manifest_file)
 
     environment_file = join(output_dir, environment['filename'])
     if exists(environment_file):

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -1148,16 +1148,24 @@ define([
       title: 'Create Manifest',
       body: [
         '<p>',
-        '    Click "Create Manifest" to create the manifest.json and requirements.txt',
-        '    files needed for publishing to RStudio Connect via git.',
+        '  Click <b>Create Manifest</b> to create the files needed ',
+        '  for publishing to RStudio Connect via git:',
         '</p>',
-        '    ',
+        '<div style="margin-left: 20px">',
         '<p>',
-        '    The requirements.txt file will be created only if it does not already exist.',
-        '    Once created, it specifies the set of Python packages that Connect will',
-        '    make available on the server during publishing. If you add imports of new',
-        '    packages, you will need to update requirements.txt to include them,',
-        '    or remove it and create the manifest again.',
+        '  <b>requirements.txt</b> lists the set of Python packages that Connect will',
+        '  make available on the server during publishing. If you add imports of new',
+        '  packages, you will need to update requirements.txt to include them,',
+        '  or remove the file and use the Create Manifest button to create it again.',
+        '</p>',
+        '<p>',
+        '  <b>manifest.json</b> specifies the version of python in use,',
+        '  along with other settings needed during deployment. Update',
+        '  or re-create this file if you update python.',
+        '</p>',
+        '</div>',
+        '<p>',
+        '  Files will be created only if needed. Existing files will not be overwritten.',
         '</p>',
         '<div id="rsc-manifest-status" style="color: red; height: 40px; margin-top: 15px;"></div>'
       ].join(''),
@@ -1187,11 +1195,12 @@ define([
               if (response.created.length > 0) {
                 $status.append($('<span>Successfully saved: </span>'));
                 $status.append(createdLinks);
+                $status.append($('<br>'));
               }
 
               if (response.skipped.length > 0) {
                 var skippedLinks = response.skipped.map(makeEditLink);
-                $status.append($('<br><span>Already existed: </span>'));
+                $status.append($('<span>Already existed: </span>'));
                 $status.append(skippedLinks);
               }
             })


### PR DESCRIPTION
### Description

This PR changes the behavior of the Create Manifest action. Previously, we would always overwrite an existing manifest.json but not overwrite requirements.txt. Now we treat them the same by not overwriting either one. The dialog text is also updated to reflect the new behavior and to look a little nicer.

Connected to #15494

### Testing Notes / Validation Steps
Use the Create Manifest window with both files missing, either one missing, both there. Ensure that files are not overwritten by editing their contents before attempting to Create Manifest.

