### PR TITLE
Fix link paths from write_manifest

### DIFF
--- a/rsconnect_jupyter/__init__.py
+++ b/rsconnect_jupyter/__init__.py
@@ -201,10 +201,11 @@ class EndpointHandler(APIHandler):
         if action == 'write_manifest':
             environment = data['environment']
             nb_path = unquote_plus(data['notebook_path'].strip('/'))
+            relative_dir = os.path.dirname(nb_path)
             os_path = self.contents_manager._get_os_path(nb_path)
             output_dir = os.path.dirname(os_path)
             nb_name = os.path.basename(os_path)
-            created, skipped = write_manifest(nb_name, environment, output_dir)
+            created, skipped = write_manifest(relative_dir, nb_name, environment, output_dir)
             self.finish(json.dumps({"created": created, "skipped": skipped}))
 
 

--- a/rsconnect_jupyter/bundle.py
+++ b/rsconnect_jupyter/bundle.py
@@ -107,7 +107,7 @@ def bundle_add_buffer(bundle, filename, contents):
     log.debug('added buffer: %s', filename)
 
 
-def write_manifest(nb_name, environment, output_dir):
+def write_manifest(relative_dir, nb_name, environment, output_dir):
     """Create a manifest for source publishing the specified notebook.
     
     The manifest will be written to `manifest.json` in the output directory..
@@ -121,21 +121,24 @@ def write_manifest(nb_name, environment, output_dir):
     created = []
     skipped = []
     
+    manifest_relpath = join(relative_dir, manifest_filename)
     if exists(manifest_file):
-        skipped.append(manifest_filename)
+        skipped.append(manifest_relpath)
     else:
         with open(manifest_file, 'w') as f:
             f.write(json.dumps(manifest, indent=2))
-            created.append(manifest_filename)
+            created.append(manifest_relpath)
             log.debug('wrote manifest file: %s', manifest_file)
 
-    environment_file = join(output_dir, environment['filename'])
+    environment_filename = environment['filename']
+    environment_file = join(output_dir, environment_filename)
+    environment_relpath = join(relative_dir, environment_filename)
     if exists(environment_file):
-        skipped.append(environment['filename'])
+        skipped.append(environment_relpath)
     else:
         with open(environment_file, 'w') as f:
             f.write(environment['contents'])
-            created.append(environment['filename'])
+            created.append(environment_relpath)
             log.debug('wrote environment file: %s', environment_file)
 
     return created, skipped

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -1122,8 +1122,10 @@ define([
       });
   }
 
-  function makeEditLink(filename) {
-    var url = Jupyter.notebook.base_url + 'edit/' + filename;
+  function makeEditLink(filepath) {
+    var url = Jupyter.notebook.base_url + 'edit/' + filepath;
+    var parts = filepath.split('/');
+    var filename = parts[parts.length - 1];
     return $('<a target="_blank" style="margin-right: 10px" href="' + url + '">' + filename + '</a>');
   }
 


### PR DESCRIPTION
### Description

The Create Manifest feature displays links to the created/existing files upon completion. These links were wrong if the notebook lived in a subdirectory. The fix is for the backend to return the relative path to the created file, instead of just the filename.

Connected to #15527

### Testing Notes / Validation Steps
Create a folder, and a notebook in that folder. Exercise the Create Manifest feature, for both new and already existing manifest.json and requirements.txt files. Do this with them existing/not existing in the notebook root directory as well. Ensure that the links open the correct files (the ones that live in the directory with the notebook that created them).
