### PR TITLE
pin twine to 1.15 for compatibility with older pythons

### DIFF
--- a/doc.Jenkinsfile
+++ b/doc.Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
             steps {
                 sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}-py2.py3-none-any.whl ."
                 sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}.tar.gz ."
-                sh "pip install --user --upgrade twine setuptools wheel"
+                sh "pip install --user --upgrade twine==1.15 setuptools wheel"
                 sh """python -m twine upload \
                     --repository-url https://test.pypi.org/legacy/ \
                     -u ${PYPI_CREDS_USR} \
@@ -77,7 +77,7 @@ pipeline {
             steps {
                 sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}-py2.py3-none-any.whl ."
                 sh "aws s3 cp s3://rstudio-rsconnect-jupyter/rsconnect_jupyter-${RELEASE_VERSION}.tar.gz ."
-                sh "pip install --user --upgrade twine setuptools wheel"
+                sh "pip install --user --upgrade twine==1.15 setuptools wheel"
                 sh """python -m twine upload \
                     -u ${PYPI_CREDS_USR} \
                     -p ${PYPI_CREDS_PSW} \


### PR DESCRIPTION
### Description

We use twine in the docs pipeline, to upload to PyPI. The latest release of twine requires python 3.6 or higher. For now, we are pinning twine to 1.15. Later, we need to figure out how to specify a docker image to use in the docs pipeline.

Connected to #https://github.com/rstudio/connect/issues/15528

### Testing Notes / Validation Steps
Run docs pipeline in dry-run mode and verify that release was published to test.pypi.org.

