### PR TITLE
Fix API key migration issue

### DIFF
--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -872,6 +872,20 @@ define([
         ) {
           form.trigger('submit');
         }
+        // force the user to update their API key for the first server in the list
+        var firstServerId = Object.keys(config.servers)[0];
+        var firstServer = config.servers[firstServerId];
+        if (!config.getApiKey(firstServer.server)) {
+          if (publishModal) {
+            publishModal.modal('hide');
+          }
+          showAddServerDialog(
+              true,
+              firstServerId,
+              firstServer.server,
+              firstServer.serverName
+          );
+        }
       }
     });
 


### PR DESCRIPTION
### Description

- If no API key specified for the first server in the list, open the add server dialog as if they had clicked the server

### Testing Notes / Validation Steps

- Should prevent the issue where existing servers do not work.