### PR TITLE
Self-signed certificates are now an option

### DIFF
--- a/rsconnect_jupyter/api.py
+++ b/rsconnect_jupyter/api.py
@@ -54,18 +54,23 @@ def wait_until(predicate, timeout, period=0.1):
 settings_path = '__api__/server_settings'
 max_redirects = 5
 
-def https_helper(hostname, port, disable_tls_check):
-    if disable_tls_check:
+def https_helper(hostname, port, disable_tls_check, cadata):
+    if cadata is not None and disable_tls_check:
+        raise Exception("Cannot both disable TLS checking and provide a custom certificate")
+    if cadata is not None:
+        return http.HTTPSConnection(hostname, port=(port or http.HTTPS_PORT), timeout=10,
+                                    context=ssl.create_default_context(cadata=cadata))
+    elif disable_tls_check:
         return http.HTTPSConnection(hostname, port=(port or http.HTTPS_PORT), timeout=10,
                                     context=ssl._create_unverified_context())
     else:
         return http.HTTPSConnection(hostname, port=(port or http.HTTPS_PORT), timeout=10)
 
-def verify_server(server_address, disable_tls_check):
+def verify_server(server_address, disable_tls_check, cadata):
     server_url = urljoin(server_address, settings_path)
-    return _verify_server(server_url, max_redirects, disable_tls_check)
+    return _verify_server(server_url, max_redirects, disable_tls_check, cadata)
 
-def _verify_server(server_address, max_redirects, disable_tls_check):
+def _verify_server(server_address, max_redirects, disable_tls_check, cadata):
     """
     Verifies that a server is present at the given address.
     Assumes that `__api__/server_settings` is accessible from the jupyter server.
@@ -78,7 +83,7 @@ def _verify_server(server_address, max_redirects, disable_tls_check):
         if r.scheme == 'http':
             conn = http.HTTPConnection(r.hostname, port=(r.port or http.HTTP_PORT), timeout=10)
         else:
-            conn = https_helper(r.hostname, r.port, disable_tls_check)
+            conn = https_helper(r.hostname, r.port, disable_tls_check, cadata)
 
         conn.request('GET', server_address)
         response = conn.getresponse()
@@ -119,13 +124,15 @@ def _verify_server(server_address, max_redirects, disable_tls_check):
 
 
 class RSConnect:
-    def __init__(self, uri, api_key, cookies=[], disable_tls_check=False):
+    def __init__(self, uri, api_key, cookies=[], disable_tls_check=False, cadata=None):
+        if disable_tls_check and (cadata is not None):
+            raise Exception("Cannot both disable TLS checking and provide custom certificate data")
         self.path_prefix = uri.path or '/'
         self.api_key = api_key
         self.conn = None
         self.mk_conn = lambda: http.HTTPConnection(uri.hostname, port=uri.port, timeout=10)
         if uri.scheme == 'https':
-            self.mk_conn = lambda: https_helper(uri.hostname, uri.port, disable_tls_check)
+            self.mk_conn = lambda: https_helper(uri.hostname, uri.port, disable_tls_check, cadata)
         self.http_headers = {
             'Authorization': 'Key %s' % self.api_key,
         }
@@ -264,8 +271,8 @@ def wait_for_task(api, task_id, timeout, period=1.0):
     return None
 
 
-def deploy(uri, api_key, app_id, app_name, app_title, tarball, disable_tls_check):
-    with RSConnect(uri, api_key, disable_tls_check=disable_tls_check) as api:
+def deploy(uri, api_key, app_id, app_name, app_title, tarball, disable_tls_check, cadata):
+    with RSConnect(uri, api_key, disable_tls_check=disable_tls_check, cadata=cadata) as api:
         if app_id is None:
             # create an app if id is not provided
             app = api.app_create(app_name)
@@ -287,18 +294,18 @@ def deploy(uri, api_key, app_id, app_name, app_title, tarball, disable_tls_check
         }
 
 
-def task_get(uri, api_key, task_id, last_status, cookies, disable_tls_check):
-    with RSConnect(uri, api_key, cookies, disable_tls_check=disable_tls_check) as api:
+def task_get(uri, api_key, task_id, last_status, cookies, disable_tls_check, cadata):
+    with RSConnect(uri, api_key, cookies, disable_tls_check=disable_tls_check, cadata=cadata) as api:
         return api.task_get(task_id, first_status=last_status)
 
 
-def app_config(uri, api_key, app_id, disable_tls_check):
-    with RSConnect(uri, api_key, disable_tls_check=disable_tls_check) as api:
+def app_config(uri, api_key, app_id, disable_tls_check, cadata):
+    with RSConnect(uri, api_key, disable_tls_check=disable_tls_check, cadata=cadata) as api:
         return api.app_config(app_id)
 
 
-def verify_api_key(uri, api_key, disable_tls_check):
-    with RSConnect(uri, api_key, disable_tls_check=disable_tls_check) as api:
+def verify_api_key(uri, api_key, disable_tls_check, cadata):
+    with RSConnect(uri, api_key, disable_tls_check=disable_tls_check, cadata=cadata) as api:
         try:
             api.me()
             return True
@@ -314,8 +321,8 @@ app_modes = {
 }
 
 
-def app_search(uri, api_key, app_title, app_id, disable_tls_check):
-    with RSConnect(uri, api_key, disable_tls_check=disable_tls_check) as api:
+def app_search(uri, api_key, app_title, app_id, disable_tls_check, cadata):
+    with RSConnect(uri, api_key, disable_tls_check=disable_tls_check, cadata=cadata) as api:
         data = []
 
         filters = [('count', 5),
@@ -352,6 +359,6 @@ def app_search(uri, api_key, app_title, app_id, disable_tls_check):
         return data
 
 
-def app_get(uri, api_key, app_id, disable_tls_check):
-    with RSConnect(uri, api_key, disable_tls_check=disable_tls_check) as api:
+def app_get(uri, api_key, app_id, disable_tls_check, cadata):
+    with RSConnect(uri, api_key, disable_tls_check=disable_tls_check, cadata=cadata) as api:
         return api.app_get(app_id)

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -237,8 +237,9 @@ define([
           '            <span class="help-block"></span>',
           '        </div>',
           '        <div class="form-group">',
+          '            <label class="rsc-label" id="rsc-tls-options">Secure Connection Settings (Optional)</label><br />',
           '            <input type="radio" name="tls-option" id="system-tls" checked />',
-          '            <label for="system-tls" class="rsc-label">Use system TLS certificates</label><br />',
+          '            <label for="system-tls" class="rsc-label">Use System TLS Certificates (Default)</label><br />',
           '            <span id="certificate-upload-container"><input type="radio" name="tls-option" id="upload-tls-certificates" />',
           '            <label for="upload-tls-certificates" class="rsc-label">Upload TLS Certificate Bundle</label></span><br />',
           '            <input type="radio" name="tls-option" id="disable-tls-verification" />',
@@ -320,6 +321,24 @@ define([
         .find('.modal-footer')
         .append(this.$btnCancel)
         .append(this.$btnAdd);
+
+      // setup TLS help icon
+
+      var msg =
+        'These settings only affect connections using addresses beginning with "https". Most users should use ' +
+        'System TLS Certificates. If you encounter a TLS error, ask your administrator for a certificate bundle. ' +
+        'If none is available, you can disable TLS verification completely.';
+
+      var helpIcon = $(
+        [
+          '<a tabindex="0" role="button" data-toggle="popover" data-trigger="focus">',
+          '<i class="fa fa-question-circle rsc-fa-icon"></i>'
+        ].join('')
+      )
+        .data('content', msg)
+        .popover();
+
+      $('#rsc-tls-options').append(helpIcon);
     },
 
     closeDialog: function() {

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -71,7 +71,7 @@ define([
     $button.find('i')
       .addClass('rsc-icon');
     $button.click(onMenuClicked);
-}
+  }
 
   /***********************************************************************
    * Helpers
@@ -103,12 +103,12 @@ define([
     };
   }
 
-    /**
-     * addValidationMarkup adds validation hints to an element
-     * @param {Boolean} valid when true, validation hints are not added
-     * @param {jQuery} $el jQuery handle for the element to add hint to
-     * @param {String} helpText String for validation message. Newlines will be transformed to HTML line breaks
-     */
+  /**
+    * addValidationMarkup adds validation hints to an element
+    * @param {Boolean} valid when true, validation hints are not added
+    * @param {jQuery} $el jQuery handle for the element to add hint to
+    * @param {String} helpText String for validation message. Newlines will be transformed to HTML line breaks
+    */
   function addValidationMarkup(valid, $el, helpText) {
     if (!valid) {
       var helpBlock = $el
@@ -138,6 +138,10 @@ define([
         .text(helpText);
   }
 
+  function maybeRemoveWarningMarkup($el) {
+    addWarningMarkup($el, '');
+  }
+
   function clearValidationMessages($parent) {
     $parent.find('.form-group').removeClass('has-error');
     $parent.find('.help-block').text('');
@@ -154,6 +158,33 @@ define([
     if (Jupyter.keyboard_manager.enabled) {
       Jupyter.keyboard_manager.disable();
     }
+  }
+
+  /**
+   * readFileToPromise reads a file but uses jquery promises rather than
+   * the native callback approach.
+   * This is used to load the CA data from the provided file.
+   * @param file {File} file gathered from input
+   */
+  function readFileToPromise(file) {
+    var reader = new FileReader();
+    var promise = $.Deferred();
+    if (!file) {
+      promise.resolve('');
+      return promise.promise();
+    }
+    reader.onload = function () {
+      promise.resolve(reader.result);
+    };
+    reader.onerror = function (err) {
+      promise.reject(err);
+    };
+    reader.readAsText(file);
+    return promise.promise();
+  }
+
+  function getCertificateUpload(ctx) {
+      return $(ctx).find('#rsc-ca-file')[0];
   }
 
   function showAddServerDialog(_config, inServerAddress, inServerName) {
@@ -206,8 +237,12 @@ define([
           '            <span class="help-block"></span>',
           '        </div>',
           '        <div class="form-group">',
-          '            <input class="form-check-input" id="rsc-disable-tls-cert-check" type="checkbox">',
-          '            <label class="rsc-label form-check-label" for="rsc-disable-tls-cert-check">Disable TLS Certificate Verification</label>',
+          '            <input type="radio" name="tls-option" id="system-tls" checked />',
+          '            <label for="system-tls" class="rsc-label">Use system TLS certificates</label><br />',
+          '            <span id="certificate-upload-container"><input type="radio" name="tls-option" id="upload-tls-certificates" />',
+          '            <label for="upload-tls-certificates" class="rsc-label">Upload TLS Certificate Bundle</label></span><br />',
+          '            <input type="radio" name="tls-option" id="disable-tls-verification" />',
+          '            <label for="disable-tls-verification" class="rsc-label">Disable TLS Verification (Not Recommended)</label>',
           '            <span class="help-block"></span>',
           '        </div>',
           '        <input type="submit" hidden>',
@@ -231,12 +266,43 @@ define([
       this.$txtServer = this.dialog.find('#rsc-server');
       this.$txtServerName = this.dialog.find('#rsc-servername');
       this.$txtApiKey = this.dialog.find('#rsc-api-key');
-      this.$checkDisableTLSCertCheck = this.dialog.find('#rsc-disable-tls-cert-check');
-
+      this.$radioSystemTLS = this.dialog.find('#system-tls');
+      this.$radioUploadTLSCertificates = this.dialog.find('#upload-tls-certificates');
+      this.$radioDisableTLSVerification = this.dialog.find('#disable-tls-verification');
       this.$txtServer.val(this.inServerAddress);
       this.$txtServerName.val(this.inServerName);
-
-      this.$checkDisableTLSCertCheck.change(this.onDisableTLSCertCheckChanged.bind(this));
+      var that = this;
+      function addCertificateUpload() {
+        var certificateUpload = document.createElement('input');
+        certificateUpload.type = 'file';
+        certificateUpload.id = 'rsc-ca-file';
+        certificateUpload.className = 'rsc-file-dialog';
+        that.dialog.find('#certificate-upload-container')
+            .append(certificateUpload);
+      }
+      function maybeRemoveCertificateUpload() {
+        var fileDialog = that.dialog.find('#rsc-ca-file');
+        if (fileDialog) {
+          fileDialog.remove();
+        }
+      }
+      function radioTLSChange() {
+        if (that.$radioDisableTLSVerification.is(':checked')) {
+          maybeRemoveCertificateUpload();
+          var disableTLSWarning = 'Disabling TLS verification will make your connection to RStudio Connect less secure';
+          addWarningMarkup(that.$radioDisableTLSVerification, disableTLSWarning);
+        } else if (that.$radioUploadTLSCertificates.is(':checked')) {
+          maybeRemoveWarningMarkup(that.$radioDisableTLSVerification);
+          addCertificateUpload();
+        } else {
+          // if systemTLS is checked
+          maybeRemoveCertificateUpload();
+          maybeRemoveWarningMarkup(that.$radioDisableTLSVerification);
+        }
+      }
+      this.$radioDisableTLSVerification.change(radioTLSChange);
+      this.$radioSystemTLS.change(radioTLSChange);
+      this.$radioUploadTLSCertificates.change(radioTLSChange);
 
       var form = this.dialog.find('form').on('submit', this.onSubmit.bind(this));
 
@@ -262,18 +328,6 @@ define([
 
     result: function() {
       return this.dialogResult;
-    },
-
-    onDisableTLSCertCheckChanged: function(ev) {
-      var checked = ev.target.checked;
-      if(checked) {
-        addWarningMarkup(
-            this.$checkDisableTLSCertCheck,
-            'Note: Checking "Disable TLS Certificate Verification" will make your connection to RStudio Connect less secure.'
-        );
-      } else {
-        addWarningMarkup(this.$checkDisableTLSCertCheck, '');
-      }
     },
 
     validate: function() {
@@ -349,14 +403,35 @@ define([
 
       if (this.validate()) {
         this.toggleAddButton(false);
-
-        this.config
-          .addServer(
-              this.$txtServer.val(),
-              this.$txtServerName.val(),
-              this.$txtApiKey.val(),
-              this.$checkDisableTLSCertCheck.is(':checked')
-          )
+        var that = this;
+        var fileCaBundleFile = getCertificateUpload(this.dialog);
+        var submit;
+        if (fileCaBundleFile) {
+          // if we have a file, we call `addServer` with TLS checking
+          // enabled and provide CA data
+          submit = readFileToPromise(fileCaBundleFile.files[0])
+              .then(function (cadata) {
+                return that.config
+                  .addServer(
+                    that.$txtServer.val(),
+                    that.$txtServerName.val(),
+                    that.$txtApiKey.val(),
+                    false,
+                    cadata
+                  );
+              });
+        } else {
+          // if not, we optionally disable TLS checking and leave CA data
+          // undefined.
+          submit = that.config
+                .addServer(
+                  that.$txtServer.val(),
+                  that.$txtServerName.val(),
+                  that.$txtApiKey.val(),
+                  that.$radioDisableTLSVerification.is(':checked')
+            );
+        }
+        submit
           .then(function(serverId) {
             self.dialogResult.resolve(serverId);
             self.dialog.modal('hide');

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -228,7 +228,7 @@ define([
           '        </div>',
           '        <div class="form-group">',
           '            <label class="rsc-label" for="rsc-api-key">API Key</label>',
-          '            <input class="form-control" id="rsc-api-key" type="password" placeholder="API key" minlength="32" maxlength="32" required>',
+          '            <input class="form-control" id="rsc-api-key" type="password" placeholder="API key" minlength="32" maxlength="32" autocomplete="off" required>',
           '            <span class="help-block"></span>',
           '        </div>',
           '        <div class="form-group">',

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -237,7 +237,7 @@ define([
           '            <span class="help-block"></span>',
           '        </div>',
           '        <div class="form-group">',
-          '            <label class="rsc-label" id="rsc-tls-options">Secure Connection Settings (Optional)</label><br />',
+          '            <label class="rsc-label" id="rsc-tls-options">Secure Connection Settings</label><br />',
           '            <input type="radio" name="tls-option" id="system-tls" checked />',
           '            <label for="system-tls" class="rsc-label">Use System TLS Certificates (Default)</label><br />',
           '            <span id="certificate-upload-container"><input type="radio" name="tls-option" id="upload-tls-certificates" />',

--- a/rsconnect_jupyter/static/main.css
+++ b/rsconnect_jupyter/static/main.css
@@ -88,6 +88,11 @@
     display:block;
 }
 
+.rsc-file-dialog {
+    margin-left: 1em;
+    display:inline !important;
+}
+
 p {
     margin-top: 15px;
 }

--- a/rsconnect_jupyter/static/rsconnect.js
+++ b/rsconnect_jupyter/static/rsconnect.js
@@ -31,6 +31,7 @@ define([
             this.previousServerId = null;
             this.servers = {};
             this.apiKeys = {};
+            this.certificates = {};
 
             // TODO more rigorous checking?
             var metadata = JSON.parse(JSON.stringify(Jupyter.notebook.metadata));
@@ -93,7 +94,7 @@ define([
                 return result;
             },
 
-            verifyServer: function (server, apiKey, disableTLSCheck) {
+            verifyServer: function (server, apiKey, disableTLSCheck, certificateData) {
                 return Utils.ajax({
                     url: Jupyter.notebook.base_url + 'rsconnect_jupyter/verify_server',
                     method: 'POST',
@@ -101,7 +102,8 @@ define([
                     data: JSON.stringify({
                         server_address: server,
                         api_key: apiKey,
-                        disable_tls_check: disableTLSCheck
+                        disable_tls_check: disableTLSCheck,
+                        cadata: certificateData
                     })
                 });
             },
@@ -113,23 +115,25 @@ define([
              * @param serverName {String} Friendly name of the server
              * @param apiKey {String} API key of the server
              * @param disableTLSCheck {Boolean} Don't verify TLS certificates
+             * @param certificateData {String} TLS Certificate Authority bundle data
              * @returns {*}
              */
-            addServer: function (server, serverName, apiKey, disableTLSCheck) {
+            addServer: function (server, serverName, apiKey, disableTLSCheck, certificateData) {
                 var self = this;
                 if (server[server.length - 1] !== '/') {
                     server += '/';
                 }
 
                 // verify the server exists, then save
-                return this.verifyServer(server, apiKey, disableTLSCheck).then(function (data) {
+                return this.verifyServer(server, apiKey, disableTLSCheck, certificateData).then(function (data) {
                     var id = data.address_hash;
                     self.servers[id] = {
                         server: data.server_address,
                         serverName: serverName,
-                        disableTLSCheck: disableTLSCheck
+                        disableTLSCheck: disableTLSCheck,
                     };
                     self.apiKeys[server] = apiKey;
+                    self.certificates[server] = certificateData;
                     return self
                         .saveConfig()
                         .then(self.saveNotebookMetadata)
@@ -141,6 +145,10 @@ define([
 
             getApiKey: function(server) {
                 return this.apiKeys[server];
+            },
+
+            getCAData: function(server) {
+                return this.certificates[server];
             },
 
             getApp: function (serverId, appId) {
@@ -155,7 +163,8 @@ define([
                         app_id: appId,
                         server_address: entry.server,
                         api_key: self.getApiKey(entry.server),
-                        disable_tls_check: entry.disableTLSCheck
+                        disable_tls_check: entry.disableTLSCheck,
+                        cadata: self.getCAData(entry.server)
                     })
                 });
             },
@@ -171,7 +180,8 @@ define([
                         server: src.server,
                         serverName: src.serverName,
                         apiKey: self.getApiKey(src.server),
-                        disableTLSCheck: src.disableTLSCheck
+                        disableTLSCheck: src.disableTLSCheck,
+                        cadata: self.getCAData(src.server)
                     };
                 }
                 return Utils.ajax({
@@ -203,6 +213,8 @@ define([
                             var entry = data[serverId];
                             self.apiKeys[entry.server] = entry.apiKey;
                             delete entry.apiKey;
+                            self.certificates[entry.server] = entry.cadata;
+                            delete entry.cadata;
 
                             if (!self.servers[serverId]) {
                                 self.servers[serverId] = entry;
@@ -343,7 +355,8 @@ define([
                                 task_id: deployResult['task_id'],
                                 last_status: lastStatus,
                                 cookies: deployResult.cookies || [],
-                                disable_tls_check: entry.disableTLSCheck
+                                disable_tls_check: entry.disableTLSCheck,
+                                cadata: self.getCAData(entry.server)
 
                             })
                         }).then(function (result) {
@@ -389,7 +402,8 @@ define([
                             server_address: entry.server,
                             api_key: self.getApiKey(entry.server),
                             app_id: receivedAppId,
-                            disable_tls_check: entry.disableTLSCheck
+                            disable_tls_check: entry.disableTLSCheck,
+                            cadata: self.getCAData(entry.server)
                         })
                     }).then(function (config) {
                         return {
@@ -411,7 +425,8 @@ define([
                         environment: environment,
                         include_files: includeFiles,
                         include_subdirs: includeSubdirs,
-                        disable_tls_check: entry.disableTLSCheck
+                        disable_tls_check: entry.disableTLSCheck,
+                        cadata: self.getCAData(entry.server)
                     };
 
                     var xhr = Utils.ajax({
@@ -459,7 +474,8 @@ define([
                         app_id: appId,
                         server_address: entry.server,
                         api_key: self.getApiKey(entry.server),
-                        disable_tls_check: entry.disableTLSCheck
+                        disable_tls_check: entry.disableTLSCheck,
+                        cadata: self.getCAData(entry.server)
                     })
                 });
             },

--- a/rsconnect_jupyter/static/rsconnect.js
+++ b/rsconnect_jupyter/static/rsconnect.js
@@ -130,7 +130,7 @@ define([
                     self.servers[id] = {
                         server: data.server_address,
                         serverName: serverName,
-                        disableTLSCheck: disableTLSCheck,
+                        disableTLSCheck: disableTLSCheck
                     };
                     self.apiKeys[server] = apiKey;
                     self.certificates[server] = certificateData;


### PR DESCRIPTION
### Description

- Expand the backend to take a `cadata` parameter which potentially contains the certificate data.
  - Treat `cadata` like API keys anywhere it's used. Note, however, that it is more like a public key than a private key so while disclosure isn't wise, there is no obvious issue to inadvertent disclosure.
- Rework the add server dialog to allow custom certificates in addition to the ability to disable TLS checking entirely

### Testing Notes / Validation Steps

1. First, ensure that you're testing on a server you don't have a trusted root certificate for. This may mean, for a dev instance of connect, that you'll have to temporarily un-trust your certificate.
2. Add a server disabling TLS checking and deploy with it.
3. Add a server using the custom certificate option and deploy with it.
4. Re-trust the root certificate, or select an RStudio Connect server you have a trusted root cert for. Select the System Certificate option and deploy with it.