### PR TITLE
Purge config entries with no API keys

### DIFF
--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -872,20 +872,6 @@ define([
         ) {
           form.trigger('submit');
         }
-        // force the user to update their API key for the first server in the list
-        var firstServerId = Object.keys(config.servers)[0];
-        var firstServer = config.servers[firstServerId];
-        if (!config.getApiKey(firstServer.server)) {
-          if (publishModal) {
-            publishModal.modal('hide');
-          }
-          showAddServerDialog(
-              true,
-              firstServerId,
-              firstServer.server,
-              firstServer.serverName
-          );
-        }
       }
     });
 

--- a/rsconnect_jupyter/static/rsconnect.js
+++ b/rsconnect_jupyter/static/rsconnect.js
@@ -193,16 +193,26 @@ define([
                     if (!self.servers) {
                         self.servers = {};
                     }
-
+                    var didDelete = false;
                     for (var serverId in data) {
-                        // Split out API keys so they're not saved into the notebook metadata.
-                        var entry = data[serverId];
-                        self.apiKeys[entry.server] = entry.apiKey;
-                        delete entry.apiKey;
+                        if (!data[serverId].apiKey) {
+                            var deleted = data[serverId];
+                            delete data[serverId];
+                            debug.info('deleted server because it had no API key: '+JSON.stringify(deleted));
+                            didDelete = true;
+                        } else {
+                            // Split out API keys so they're not saved into the notebook metadata.
+                            var entry = data[serverId];
+                            self.apiKeys[entry.server] = entry.apiKey;
+                            delete entry.apiKey;
 
-                        if (!self.servers[serverId]) {
-                            self.servers[serverId] = entry;
+                            if (!self.servers[serverId]) {
+                                self.servers[serverId] = entry;
+                            }
                         }
+                    }
+                    if (didDelete) {
+                        self.saveConfig().then(self.saveNotebookMetadata);
                     }
                 });
             },


### PR DESCRIPTION
### Description

- On config load, detect entries with no API key and remove them, logging as we go.
- If we removed any, save the config again.
- Remove the code that automatically loads the add server dialog for the first server if it has no API key.

### Testing Notes / Validation Steps

- Go to `~/.jupyter/nbconfig/rsconnect_jupyter.json` and remove the API key for a server entry
- Open the Publish (Server Selection) dialog. The console should confirm that the entry with no API key was removed and the config was resaved.
- No other config entries should have been removed.