### PR TITLE
Jsk selenium stuff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN conda update conda
 
 USER ${NB_UID}:${NB_GID}
 RUN bash -c 'cd /home/builder \
-    && conda create --yes --channel conda-forge --name py${PY_VERSION/./} python=${PY_VERSION} jupyter setuptools pip'
+    && conda create --yes --channel conda-forge --name py${PY_VERSION/./} python=${PY_VERSION} jupyter numpy matplotlib setuptools pip'

--- a/selenium/t/test_publish_static.py
+++ b/selenium/t/test_publish_static.py
@@ -45,5 +45,6 @@ class TestPublishStatic(object):
 
         m = MainToolBar()
         notification = m.rsconnect_notification
+        sleep(1) # race
         notification.should(be.visible)
         notification.should(have.text('Successfully published content'))

--- a/selenium/t/test_republish.py
+++ b/selenium/t/test_republish.py
@@ -46,6 +46,7 @@ class TestRepublish(object):
 
         m = MainToolBar()
         notification = m.rsconnect_notification
+        sleep(1) # race
         notification.should(be.visible)
         notification.should(have.text('Successfully published content'))
 

--- a/selenium/t/test_switch_mode.py
+++ b/selenium/t/test_switch_mode.py
@@ -46,6 +46,7 @@ class TestSwitchMode(object):
 
         m = MainToolBar()
         notification = m.rsconnect_notification
+        sleep(1) # race
         notification.should(be.visible)
         notification.should(have.text('Successfully published content'))
 


### PR DESCRIPTION
### Description

This change includes the following:

- Updates the mock Connect code to correctly assign a GUID for new apps and brings it into PEP8/linting compliance.  A cleaner ID generator scheme was added also.
- Updates the Conda environment so that building the notebooks for the static deploy tests works (needed to include the `matplotlib` library and its deps).
- Delays were added in different parts of the Selenium tests to avoid race conditions.

Connected to #n/a

### Testing Notes / Validation Steps

- [ ] `make test-selenium` now runs and terminates cleanly.