### PR TITLE
pin rsconnect-jupyter 1.3.0 to rsconnect-python 1.3.0.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ all-tests: test2 test3.5 test3.6 test3.7
 
 test:
 # TODO run in container
-	pip install --extra-index-url=https://test.pypi.org/simple rsconnect-python
 	python -V
 	python -Wi setup.py test
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='rsconnect_jupyter',
       license='GPL-2.0',
       packages=['rsconnect_jupyter'],
       install_requires=[
-          'rsconnect-python==0.1.*',
+          'rsconnect-python==1.3.0.*',
           'notebook',
           'nbformat',
           'nbconvert>=5.0',


### PR DESCRIPTION
### Description

- Updates the `setup.py` to require `rsconnect-python` 1.3.0.x

### Testing Notes / Validation Steps

- `python setup.py install` or an installation of the wheel should automatically install `rsconnect-python` from pip if not found. You may wish to remove `rsconnect-python` globally by doing `pip uninstall rsconnect-python` before testing.