### PR TITLE
Show an appropriate error when rsconnect package not found in kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
 Note: The above commands only need to be run once when installing
 `rsconnect_jupyter`.
 
+Note: In order to deploy content, you will need at least the 
+[rsconnect-python](https://github.com/rstudio/rsconnect-python) package
+in every kernel you plan to deploy from.
+
 Note: If you run into an issue during installation please let us know by filing
 a bug [here](https://github.com/rstudio/rsconnect-jupyter/issues).
 

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -1158,7 +1158,15 @@ define([
 
           function handleFailure(xhr) {
             var msg;
-            if (xhr.status === 500) {
+            if (
+                typeof xhr === 'string' &&
+                xhr.match(/ModuleNotFoundError: No module named 'rsconnect'/) !== null
+            ) {
+                msg = 'The rsconnect-python package is not installed in your current notebook kernel.<br />' +
+                    'See the <a href="https://docs.rstudio.com/rsconnect-jupyter/#installation" target="_blank">' +
+                    'Installation Section of the rsconnect-jupyter documentation</a> for more information.';
+            }
+            else if (xhr.status === 500) {
                 msg = 'An internal error occurred.';
             }
             else if (xhr.responseJSON) {
@@ -1613,14 +1621,25 @@ define([
                 $status.append(skippedLinks);
               }
             })
-.fail(function(response) {
+            .fail(function(response) {
               $status.text(response.responseJSON.message);
             });
           })
-.fail(function(response) {
-            $status.text(response.responseJSON.message);
+          .fail(function(response) {
+            if (
+              typeof response === 'string' &&
+              response.match(/ModuleNotFoundError: No module named 'rsconnect'/) !== null
+            ) {
+              $status.html(
+             'The rsconnect-python package is not installed in your current notebook kernel.<br />' +
+                  'See the <a href="https://docs.rstudio.com/rsconnect-jupyter/#installation" target="_blank">' +
+                  'Installation Section of the rsconnect-jupyter documentation</a> for more information.'
+              );
+            } else {
+              $status.text(response.responseJSON.message);
+            }
           })
-.always(function() {
+          .always(function() {
             $spinner.remove();
             btnCreateManifest.attr('disabled', false);
           });


### PR DESCRIPTION
### Description

- Detect when we can't find the `rsconnect` module in the kernel and return a more appropriate error message
- Update docs to clarify that at least `rsconnect-python` needs to be available in every kernel.


### Testing Notes / Validation Steps

- Create a new kernelspec:

`python -m ipykernel install --user --name test --display-name "Env without rsconnect-python in it"`

- Create a new notebook using this kernelspec in a notebook server with the plugin properly installed

1. Try to deploy. Proper error message should be returned

2. Try to generate a manifest. Same error message should be returned.