### PR TITLE
Warn on version mismatch - report version information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /*.eggs
 .DS_Store
 .vagrant
+/rsconnect_jupyter/static/version.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.md
 include rsconnect_jupyter/static/*.js
+include rsconnect_jupyter/static/*.json
 include rsconnect_jupyter/static/main.css
 include rsconnect_jupyter/static/images/*.png
 include rsconnect_jupyter/version.txt

--- a/rsconnect_jupyter/__init__.py
+++ b/rsconnect_jupyter/__init__.py
@@ -10,7 +10,7 @@ from notebook.base.handlers import APIHandler
 from notebook.utils import url_path_join
 from tornado import web
 
-from rsconnect.api import app_search, verify_server, verify_api_key, RSConnect, RSConnectException
+from rsconnect.api import app_search, verify_server, verify_api_key, RSConnect, RSConnectException, VERSION
 from rsconnect.bundle import make_notebook_html_bundle, make_notebook_source_bundle, write_manifest
 
 from ssl import SSLError
@@ -211,6 +211,17 @@ class EndpointHandler(APIHandler):
             nb_name = os.path.basename(os_path)
             created, skipped = write_manifest(relative_dir, nb_name, environment, output_dir)
             self.finish(json.dumps({"created": created, "skipped": skipped}))
+
+    @web.authenticated
+    def get(self, action):
+        if action == 'plugin_version':
+            rsconnect_jupyter_server_extension = __version__
+            rsconnect_python_version = VERSION
+            self.finish(json.dumps({
+                "rsconnect_jupyter_server_extension": rsconnect_jupyter_server_extension,
+                "rsconnect_python_version": rsconnect_python_version
+            }))
+
 
 
 def load_jupyter_server_extension(nb_app):

--- a/rsconnect_jupyter/static/main.css
+++ b/rsconnect_jupyter/static/main.css
@@ -117,3 +117,8 @@ p {
     margin-right: 1em;
     margin-bottom: 2em;
 }
+
+#version-info {
+    font-size: .7em;
+    text-align: right;
+}

--- a/rsconnect_jupyter/static/rsconnect.js
+++ b/rsconnect_jupyter/static/rsconnect.js
@@ -509,6 +509,21 @@ define([
                 }
                 // default title
                 return Jupyter.notebook.get_notebook_name();
+            },
+
+            getVersionInfo: function () {
+                return Utils.ajax({
+                    url: Jupyter.notebook.base_url + 'rsconnect_jupyter/plugin_version'
+                })
+                    .then(function (version_info) {
+                        return Utils.ajax({
+                            url: Jupyter.notebook.base_url + 'nbextensions/rsconnect_jupyter/version.json'
+                        })
+                            .then(function (js_version_info) {
+                                version_info.js_version = js_version_info.version;
+                                return version_info;
+                            });
+                    });
             }
         };
 

--- a/selenium/t/pages/publish_content_form.py
+++ b/selenium/t/pages/publish_content_form.py
@@ -38,3 +38,7 @@ class PublishContentForm(FormBase):
     @property
     def title_error(self):
         return s(by.css('#rsc-deploy-error'))
+
+    @property
+    def version_info(self):
+        return s(by.css('#version-info'))

--- a/selenium/t/test_publish_source.py
+++ b/selenium/t/test_publish_source.py
@@ -39,6 +39,7 @@ class TestPublishSource(object):
         # dialog is racy with event setup
         sleep(1)
 
+        pf.version_info.should(be.visible)
         pf.title.set_value('NotebookSource')
         pf.publish_with_source.click()
         pf.submit.click()

--- a/selenium/t/test_publish_source.py
+++ b/selenium/t/test_publish_source.py
@@ -40,6 +40,7 @@ class TestPublishSource(object):
         sleep(1)
 
         pf.version_info.should(be.visible)
+        pf.version_info.should(have.text('rsconnect-python version'))
         pf.title.set_value('NotebookSource')
         pf.publish_with_source.click()
         pf.submit.click()


### PR DESCRIPTION
### Description

- Make the server extension gather version information
- Add a make target to produce a javascript-consumable version file
- Report all in the jupyter extension interface
- If JS and server extension don't match, warn conspicuously

### Testing Notes / Validation Steps

To test the version mismatch response, clone the repo, run `make version-frontend` and change the version number for the frontend.  Then, upon opening the publish or create-manifest dialog, it should raise an error dialog.

Additionally, in all cases, the versions should be appended to the console log as well as at the bottom right of the publish and create manifest dialogs.