### PR TITLE
Fix an issue where running from a virtualenv with bad characters caused environment inspection to fail

### DIFF
--- a/rsconnect_jupyter/static/rsconnect.js
+++ b/rsconnect_jupyter/static/rsconnect.js
@@ -269,9 +269,9 @@ define([
               return this.getRunningPythonPath().then(function(pythonPath) {
                 try {
                     var cmd = [
-                        '!',
+                        '!"',
                         pythonPath,
-                        ' -m rsconnect.environment ${PWD}'
+                        '" -m rsconnect.environment "${PWD}"'
                     ].join('');
                     console.log('executing: ' + cmd);
                 } catch (e) {


### PR DESCRIPTION
### Description

- Hard quote the python path in `inspectEnvironment`

#### Note to Users

We do **not** recommend running python in virtual environments with spaces, parenethesis, or other special characters in the directory path. Hashbangs do not work and you will run into unexpected difficulties with tools from all over the python ecosystem.

### Testing Notes / Validation Steps

The hardest part about this is testing. Good luck.

There are two ways you can approach this by my reckoning:

1. `mkdir "<some directory name with characters that shouldn't properly be in directories>"`
2. `cd !$`
3. `virtualenv hello`
4. `source hello/bin/activate`
or

1. `virtualenv "<some env name with characters that shouldn't properly be in directories>"`
2. `cd !$`
3. `source bin/activate`

I've used the second so it might provide better coverage to do the first.

You then need to alter basically every step of installation: (background: https://github.com/pypa/pip/issues/923)

You must be:

1. Activated in the offending virtualenv
2. Inside the `rsconnect-jupyter` repository root

```
# Every python utility, including pip, uses hashpaths to define interpreter and therefore does not work.
# See: https://github.com/pypa/pip/issues/923
python -m pip install jupyter-notebook

python setup.py install

python "`which jupyter-nbextension`" install --sys-prefix --py rsconnect_jupyter
python "`which jupyter-nbextension`" enable --sys-prefix --py rsconnect_jupyter
python "`which jupyter-serverextension`" enable --sys-prefix --py rsconnect_jupyter
```

Finally, you can't even start up `jupyter-notebook` without:

```
python "`which jupyter-notebook`"
```

Test deployment and generating a manifest. Nothing more complex than that. Just takes a while to get the environment ready.