### PR TITLE
Always use compatibility mode.

### DIFF
--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -1367,6 +1367,11 @@ define([
             compatibilityMode = false;
             environmentOptions = 'use-existing-conda';
           }
+          if (!isCondaEnvironment) {
+            // TODO: This is needed to force `requirements.txt` to be generated
+            // TODO: until conda support is delivered
+            compatibilityMode = false;
+          }
 
           var validTitle = txtTitle.val().length >= 3;
 


### PR DESCRIPTION
### Description

We need to ensure compatibility mode is always set, otherwise `environment.py` will capture conda environments.

### Testing Notes / Validation Steps

Conda environments should never be generated.