### PR TITLE
Bump rsconnect-python version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='rsconnect_jupyter',
       license='GPL-2.0',
       packages=['rsconnect_jupyter'],
       install_requires=[
-          'rsconnect-python==1.3.2.*',
+          'rsconnect-python==1.4.0.*',
           'notebook',
           'nbformat',
           'nbconvert>=5.0',


### PR DESCRIPTION
### Description

This change bumps the required version of `rsconnect-python`.

Connected to #n/a

### Testing Notes / Validation Steps

- [ ] Everything should still work.