### PR TITLE
Bump rsconnect-python version and NEWS it.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# v1.3.1
+- Bump version of `rsconnect-jupyter` used.
+
 # v1.3.0
 - Core functionality was moved to the `rsconnect-python` package, which includes a
   command-line interface for convenience. See https://github.com/rstudio/rsconnect-python

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='rsconnect_jupyter',
       license='GPL-2.0',
       packages=['rsconnect_jupyter'],
       install_requires=[
-          'rsconnect-python==1.4.0.*',
+          'rsconnect-python==1.4.1.*',
           'notebook',
           'nbformat',
           'nbconvert>=5.0',


### PR DESCRIPTION
### Description

This change bumps the version of `rsconnect-python` to pick up a fix for Connect in an HA/clustered environment.

Connected to #n/a

### Testing Notes / Validation Steps

n/a -- just a version bump of a dependent library.