### PR TITLE
One more rscp version bump before 1.3.2 goes out.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='rsconnect_jupyter',
       license='GPL-2.0',
       packages=['rsconnect_jupyter'],
       install_requires=[
-          'rsconnect-python==1.4.2.*',
+          'rsconnect-python==1.4.3.*',
           'notebook',
           'nbformat',
           'nbconvert>=5.0',


### PR DESCRIPTION
### Description

This change bumps the version of `rsconnect-python` we require.  This is needed to make sure the best code is being used before we publish `rsconnect-jupyter`.

Connected to #n/a

### Testing Notes / Validation Steps

n/a -- just a bump in a dependent library version.