### PR TITLE
Bump rsconnect-python dependency to latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='rsconnect_jupyter',
       license='GPL-2.0',
       packages=['rsconnect_jupyter'],
       install_requires=[
-          'rsconnect-python==1.4.4.*',
+          'rsconnect-python==1.4.5.*',
           'notebook',
           'nbformat',
           'nbconvert>=5.0',


### PR DESCRIPTION
### Description

- Bump `rsconnect-python` dependency to latest version. Note that it is not on pip and you'll have to install it via 

`pip install -e git+https://github.com/rstudio/rsconnect-python#egg=rsconnect_python`

### Testing Notes / Validation Steps

Internal/none