### PR TITLE
Better environment error handling

### DIFF
--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -1412,7 +1412,7 @@ define([
             } else if (xhr.responseText) {
               msg = 'Error: ' + xhr.responseText;
             } else {
-              msg = 'An unknown error occurred.';
+              msg = 'An unknown error occurred.' + JSON.stringify(xhr);
             }
             addValidationMarkup(false, $deploy_err, msg);
             togglePublishButton(true);

--- a/rsconnect_jupyter/static/rsconnect.js
+++ b/rsconnect_jupyter/static/rsconnect.js
@@ -296,7 +296,13 @@ define([
                     if (count('{', content) === count('}', content)) {
                         try {
                             debug.info('environment:', content);
-                            result.resolve(JSON.parse(content));
+                            var parsedContent = JSON.parse(content);
+                            if (parsedContent.error) {
+                                debug.error('environment error:', parsedContent);
+                                result.reject(parsedContent);
+                            } else {
+                                result.resolve(parsedContent);
+                            }
                         } catch (err) {
                             debug.info('environment error:', err);
                             result.reject(content);


### PR DESCRIPTION
### Description

- We were previously eating errors from `environment.py` when the script exited with code 0. This is possibly also a bug in `environment.py` insofar as it exits with `0` in an error case...

### Testing Notes / Validation Steps

- Try to deploy a notebook in a directory where `requirements.txt` exists but your current user does not have permission to read from it. The error in the web UI should be appropriate.