### PR TITLE
Add support for legacy promises

### DIFF
--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -30,7 +30,7 @@ define([
    */
   function legacyPromiseHandler(result, callback) {
     if (result instanceof window.Promise) {
-      verbose('Using legacy promise mode.')
+      verbose('Using legacy promise mode.');
       return result.then(callback);
     } else {
       return callback(result);

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -19,6 +19,23 @@ define([
       console.error.apply(window, arguments);
     }
   }
+
+  /**
+   * legacyPromiseHandler applies a function to a result whether or not
+   * it's a plain value or a promise.
+   * @param result {Promise|any} either a promise or a plain value
+   * @param callback {Function} a function that takes result as a plain value
+   * @returns {Promise|any} If result was a promise, a promise. If result was a
+   * plain value, a plain value.
+   */
+  function legacyPromiseHandler(result, callback) {
+    if (result instanceof window.Promise) {
+      verbose('Using legacy promise mode.')
+      return result.then(callback);
+    } else {
+      return callback(result);
+    }
+  }
   // this will be filled in by `init()`
   var notify = null;
 
@@ -1171,32 +1188,18 @@ define([
                   }
                 }
               }
-              if (result instanceof window.Promise) {
-                verbose('Using legacy promise mode.');
-                return result.then(getRequirements);
-              } else {
-                return getRequirements(result);
-              }
+              return legacyPromiseHandler(result, getRequirements);
             })
             .then(function(result) {
-              if (result instanceof window.Promise) {
-                result.then(function () {
-                      preparePublishRequirementsTxtDialog(
-                          hasRequirementsTxt,
-                          hasEnvironmentYml,
-                          isCondaEnvironment,
-                          environmentOptions
-                      );
-                    }
-                );
-              } else {
+              function doPrepare() {
                 preparePublishRequirementsTxtDialog(
-                          hasRequirementsTxt,
-                          hasEnvironmentYml,
-                          isCondaEnvironment,
-                          environmentOptions
+                    hasRequirementsTxt,
+                    hasEnvironmentYml,
+                    isCondaEnvironment,
+                    environmentOptions
                 );
               }
+              return legacyPromiseHandler(result, doPrepare);
             });
 
         // generate server list
@@ -1976,29 +1979,16 @@ define([
                   }
                 }
               }
-
-              if (result instanceof window.Promise) {
-                verbose('Using legacy promise mode.');
-                return result.then(getRequirements);
-              } else {
-                return getRequirements(result);
-              }
+              return legacyPromiseHandler(result, getRequirements);
             })
             .then(function (result) {
-if (result instanceof window.Promise) {
-                result.then(function () {
+              function doPrepare() {
                 prepareManifestRequirementsTxtDialog(
-                          hasRequirementsTxt,
-                          hasEnvironmentYml,
-                          isCondaEnvironment);
-                    }
-                );
-              } else {
-                prepareManifestRequirementsTxtDialog(
-                          hasRequirementsTxt,
-                          hasEnvironmentYml,
-                          isCondaEnvironment);
+                    hasRequirementsTxt,
+                    hasEnvironmentYml,
+                    isCondaEnvironment);
               }
+              return legacyPromiseHandler(result, doPrepare);
             });
 
         var btnCancel = $(

--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -1963,16 +1963,42 @@ define([
             .then(function() {
               return ContentsManager.list_contents(notebookDirectory);
             })
-            .then(function (contents) {
-              for(var index in contents.content) {
-                if (contents.content[index].name === 'requirements.txt') {
-                  hasRequirementsTxt = true;
-                } else if (contents.content[index].name === 'environment.yml') {
-                  // TODO: Enable when ready
-                  // hasEnvironmentYml = true;
+            .then(function (result) {
+              function getRequirements(contents) {
+                verbose('contents:', contents);
+                for (var index in contents.content) {
+                  if (contents.content[index].name === 'requirements.txt') {
+                    verbose('Found requirements.txt:', contents.content[index]);
+                    hasRequirementsTxt = true;
+                  } else if (contents.content[index].name === 'environment.yml') {
+                    // TODO: Enable when ready
+                    // hasEnvironmentYml = true;
+                  }
                 }
               }
-              prepareManifestRequirementsTxtDialog(hasRequirementsTxt, hasEnvironmentYml, isCondaEnvironment);
+
+              if (result instanceof window.Promise) {
+                verbose('Using legacy promise mode.');
+                return result.then(getRequirements);
+              } else {
+                return getRequirements(result);
+              }
+            })
+            .then(function (result) {
+if (result instanceof window.Promise) {
+                result.then(function () {
+                prepareManifestRequirementsTxtDialog(
+                          hasRequirementsTxt,
+                          hasEnvironmentYml,
+                          isCondaEnvironment);
+                    }
+                );
+              } else {
+                prepareManifestRequirementsTxtDialog(
+                          hasRequirementsTxt,
+                          hasEnvironmentYml,
+                          isCondaEnvironment);
+              }
             });
 
         var btnCancel = $(


### PR DESCRIPTION
### Description

- We use `ContentManager.get_contents` in three places:
https://github.com/rstudio/rsconnect-jupyter/blob/5462efcf94bc4f5deaabf8d86d181e92001f74d6/rsconnect_jupyter/static/connect.js#L317
https://github.com/rstudio/rsconnect-jupyter/blob/5462efcf94bc4f5deaabf8d86d181e92001f74d6/rsconnect_jupyter/static/connect.js#L1159
https://github.com/rstudio/rsconnect-jupyter/blob/5462efcf94bc4f5deaabf8d86d181e92001f74d6/rsconnect_jupyter/static/connect.js#L1964

- In the first place, we use it as a promise, so it's fine.
- In the second and third places, there's a difference in Jupyter versions as to whether one can return a promise as part of a promise `then` handler- if a promise is returned in legacy mode, the handler doesn't block on that promise resolving but just passes it directly as an argument to the next `then` handler. This means we have to bifurcate handling of promise returners (or avoid promise returners entirely) and basically say "are you a promise? if so, do this as a `then` handler. Otherwise, do this as you would to another function".
- This was causing older versions (5.4.0~) of Jupyter notebook not to be able to recognize the presence of a `requirements.txt`

Connected to #

### Testing Notes / Validation Steps

- [ ] Install jupyter-notebook 5.4.0 
- [ ] Open a notebook where a `requirements.txt` exists in the notebook directory
- [ ] Open the write-manifest dialog. Observe that we give the option to use the existing `requirements.txt`
- [ ] Open the deploy dialog. Observe that we give the option to use the existing `requirements.txt`