### PR TITLE
replace PWD with an empty string which means the same thing but can be understood on windows

### DIFF
--- a/rsconnect_jupyter/static/rsconnect.js
+++ b/rsconnect_jupyter/static/rsconnect.js
@@ -276,7 +276,7 @@ define([
                         '!"',
                         pythonPath,
                         '" -m rsconnect.environment ' +
-                        flags + ' "${PWD}"'
+                        flags + ' ""'
                     ].join('');
                     console.log('executing: ' + cmd);
                 } catch (e) {


### PR DESCRIPTION
### Description

Support ticket illustrated that a `requirements.txt` was not being picked up on Windows 10. Upon testing locally it was found that on Windows 10, the jupyter shell does not replace `${PWD}` and it gets passed straight to `environment.py`, which looks for `${PWD}/requirements.txt` literally rather than with a cwd substitution. Instead, we pass an empty string argument which then becomes `./requirements.txt`, i.e.: the same thing.

### Testing Notes / Validation Steps

```
vagrant up
```

Test a deploy under Windows with a preexisting `requirements.txt`.

Look in the console logs in jupyter notebook. We should be picking up the file and not generating one from `pip freeze`