### PR TITLE
Show details for internal errors

### DIFF
--- a/rsconnect_jupyter/static/connect.js
+++ b/rsconnect_jupyter/static/connect.js
@@ -1415,8 +1415,6 @@ define([
                   'Installation Section of the rsconnect-jupyter documentation</a> for more information.';
             } else if (typeof xhr === 'string') {
               msg = 'An unexpected error occurred: ' + xhr;
-            } else if (xhr.status === 500) {
-              msg = 'An internal error occurred.';
             } else if (xhr.responseJSON) {
               if (xhr.responseJSON.message) {
                 msg = 'Error: ' + xhr.responseJSON.message;


### PR DESCRIPTION
### Description

This PR shows the returned error messages for all cases, to make troubleshooting easier. Previously, errors resulting in a 500 status would suppress all of the error details. 

Connected to #276 

### Testing Notes / Validation Steps
Create an error. For example, add notebook code that fails to import a module, then try to publish the finished document only. The resulting error should indicate that nbconvert failed, rather than saying "an internal error occurred".
