### PR TITLE
Don't publish docs on beta releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,11 +118,11 @@ jobs:
         aws-region: us-east-1
     - if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: make sync-latest-docs-to-s3
-    - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && (contains(github.ref, 'b') == false)
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.DOCS_AWS_ID }}
         aws-secret-access-key: ${{ secrets.DOCS_AWS_SECRET }}
         aws-region: us-east-1
-    - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && (contains(github.ref, 'b') == false)
       run: make promote-docs-in-s3


### PR DESCRIPTION
### Description

This PR changes our Github Actions CI setup so that it no longer publishes the docs if the tag being built is a beta release. Previously, we were promoting the docs to released status too soon.

Connected to #300

### Testing Notes / Validation Steps

When we publish the next beta release, docs should be built and pushed to s3 but not promoted to docs.rstudio.com.
