### PR TITLE
update setuptools_scm for publishing to PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,4 @@ target-version = ["py35"]
 
 [tool.setuptools_scm]
 write_to = "rsconnect_jupyter/version.py"
+use_scm_version = {"local_scheme" = ""}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,4 @@ target-version = ["py35"]
 
 [tool.setuptools_scm]
 write_to = "rsconnect_jupyter/version.py"
-use_scm_version = {"local_scheme" = ""}
+local_scheme = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,4 @@ target-version = ["py35"]
 
 [tool.setuptools_scm]
 write_to = "rsconnect_jupyter/version.py"
-local_scheme = ""
+local_scheme = "no-local-version"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,8 @@
 from setuptools import setup
-
-setup()
+ 
+def local_scheme(version):
+    return ""
+ 
+setup(
+    use_scm_version={"local_scheme": local_scheme},
+)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 from setuptools import setup
- 
+
+
 def local_scheme(version):
     return ""
- 
+
+
 setup(
     use_scm_version={"local_scheme": local_scheme},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,3 @@
 from setuptools import setup
 
-
-def local_scheme(version):
-    return ""
-
-
-setup(
-    use_scm_version={"local_scheme": local_scheme},
-)
+setup()


### PR DESCRIPTION
### Description

fixes the following error in the tag to publish CI:

> is an invalid value for Version. Error: Can't use PEP 440 local versions.

### Background

setuptools_scm creates local version hash (e.g. the plus part of a .whl file "+abcde") that are disallowed when publishing to PyPI. The PR changes removes the local version hash so publishing to PYPI can succeed.

