### PR TITLE
Enable md5 in FIPS mode

### DIFF
--- a/rsconnect_jupyter/__init__.py
+++ b/rsconnect_jupyter/__init__.py
@@ -58,7 +58,14 @@ def md5(s):
     if hasattr(s, "encode"):
         s = s.encode("utf-8")
 
-    h = hashlib.md5()
+    try:
+        h = hashlib.md5()
+    except Exception:
+        # md5 is not available in FIPS mode, see if the usedforsecurity option is available
+        # (it was added in python 3.9). We set usedforsecurity=False since we are only
+        # using this for a file upload integrity check.
+        h = hashlib.md5(usedforsecurity=False)
+
     h.update(s)
     return h.hexdigest()
 


### PR DESCRIPTION
### Description

The `hashlib.md5` function is not available in FIPS mode. In Python 3.9+, there is a new `usedforsecurity` flag that can be passed to allow the use of MD5 if you indicate that it is not for security purposes. rsconnect-jupyter uses md5 to construct unique identifiers from URLs containing only "safe" characters.

Fixes #325 

### Testing Notes / Validation Steps

To test this thoroughly requires a system in FIPS mode. I am using a Vagrant centos7 box, with FIPS mode enabled following the instructions [here](https://www.thegeekdiary.com/how-to-make-centos-rhel-7-fips-140-2-compliant/). I built Python 3.9 with the FIPS patch following the instructions [here](https://www.gyanblog.com/security/how-build-patch-python-3.9.x-fips-enable/). You can also verify the the system Python (which is Python 3.6) does not work.
