### PR TITLE
switch docs from AWSID/secret to a role

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,8 +123,7 @@ jobs:
     - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && (contains(github.ref, 'b') == false)
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.DOCS_AWS_ID }}
-        aws-secret-access-key: ${{ secrets.DOCS_AWS_SECRET }}
+        role-to-assume: ${{ secrets.DOCS_AWS_ROLE }}
         aws-region: us-east-1
     - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && (contains(github.ref, 'b') == false)
       run: make promote-docs-in-s3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ on:
     types: [rsconnect_python_latest]
 env:
   DOCKER_TTY_FLAGS: ''
+permissions:
+  id-token: write
+  contents: write
 jobs:
   test:
     strategy:


### PR DESCRIPTION
### Description

Switch the docs upload from using an AWS ID and secret (both repo secrets) to using an assumed role (also a repo secret).

### Testing Notes / Validation Steps

This will be exercised when we tag the beta of the next release.
