### PR TITLE
update GH actions to use OpenID connect

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,10 +94,10 @@ jobs:
         asset_name: ${{ steps.create_dist.outputs.whl_basename }}
         asset_content_type: application/x-wheel+zip
     - uses: aws-actions/configure-aws-credentials@v1
+      id: creds
       with:
-        aws-access-key-id: ${{ secrets.AWS_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET }}
-        aws-region: us-east-1
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        aws-region: ${{ secrets.AWS_REGION }}
     - if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: make sync-latest-to-s3
     - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
@@ -117,10 +117,10 @@ jobs:
         name: docs
         path: docs/site/
     - uses: aws-actions/configure-aws-credentials@v1
+      id: creds
       with:
-        aws-access-key-id: ${{ secrets.AWS_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET }}
-        aws-region: us-east-1
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        aws-region: ${{ secrets.AWS_REGION }}
     - if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: make sync-latest-docs-to-s3
     - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && (contains(github.ref, 'b') == false)


### PR DESCRIPTION
### Intent

This PR updates the CI and supported versions workflows to use the GitHubActions role in AWS instead of fixed credentials.

Fixes [#22293](https://github.com/rstudio/connect/issues/22293)

Once merged we will need to delete the `AWS_SECRET` in GH Actions Secrets (repo Settings).

### QA Notes

- [ ] All workflows pass CI.


