### PR TITLE
Snyk integration fix

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Pipfile.lock dependencies
+        run: pipenv sync
+
       - name: Run Snyk
         uses: snyk/actions/python@master
         with:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -16,6 +16,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install pipenv
+        run: |
+          python -m pip install --upgrade pipenv
+
       - name: Install Pipfile.lock dependencies
         run: pipenv sync
 

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -9,7 +9,7 @@ env:
   SNYK_ORG: rstudio-connect
 
 jobs:
-  snyk-monitor:
+  python:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -20,11 +20,23 @@ jobs:
         run: |
           python -m pip install --upgrade pipenv
 
-      - name: Install Pipfile.lock dependencies
-        run: pipenv sync
+      - name: Install Pipfile dependencies (as required by Snyk)
+        run: pipenv install
 
       - name: Run Snyk
         uses: snyk/actions/python@master
         with:
           command: monitor
-          args: --file=Pipfile --org=${{ env.SNYK_ORG }}
+          args: --file=Pipfile --project-name=python --org=${{ env.SNYK_ORG }}
+  ui:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Run Snyk
+        uses: snyk/actions/node@master
+        with:
+          command: monitor
+          args: --file=yarn.lock --project-name=ui --org=${{ env.SNYK_ORG }}


### PR DESCRIPTION
- Use the `Pipfile` directly, as Snyk does not play nice when trying to use the Pipfile.lock
- Also scan the `yarn.lock` for front-end dependencies (although there currently are only development deps)

Closes #338 