### PR TITLE
Add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ on:
     branches: [master]
   repository_dispatch:
     types: [rsconnect_python_latest]
+  workflow_dispatch:
+
 env:
   DOCKER_TTY_FLAGS: ''
 permissions:


### PR DESCRIPTION
To make debugging CI issues easier, this PR adds a `workflow_dispatch` trigger to CI.
