### PR TITLE
Add deployment instructions to CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,27 @@
-# User Guide
+# Contributing Guidelines
 
-Installation and usage instructions are available
-[here](https://github.com/rstudio/rsconnect-jupyter/tree/master/docs).
+This documentation covers common tasks releated to development.
 
-# Developing `rsconnect-jupyter`
+For installation and usage instructions see [README.md](./README.md).
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+- [Contributing Guidelines](#contributing-guidelines)
+- [Development](#development)
+    - [Trying out notebooks](#trying-out-notebooks)
+    - [Seeing code changes](#seeing-code-changes)
+- [Packaging](#packaging)
+- [Versioning and Releases](#versioning-and-releases)
+    - [Versioning](#versioning)
+    - [Releases](#releases)
+        - [Releasing on Conda Forge](#releasing-on-conda-forge)
+        - [Adding yourself as a rsconnect-jupyter conda-forge maintainer](#adding-yourself-as-a-rsconnect-jupyter-conda-forge-maintainer)
+
+<!-- markdown-toc end -->
+
+
+# Development
 
 Need to run this after checkout and when modifying the docker images
 
@@ -49,10 +67,31 @@ The following will create a universal [wheel](https://pythonwheels.com/) ready
 to be installed in any python 2 or python 3 environment.
 
     make package
+# Versioning and Releases
 
-## Updating rsconnect-jupyter on conda-forge
+## Versioning
 
-rsconnect-jupyter exists on conda-forge as its own [feedstock](https://github.com/conda-forge/rsconnect-jupyter-feedstock)
+Versioning is accomplished via Git tagging using [Semantic Versioning](https://semver.org/). Read more about tagging [here](https://git-scm.com/book/en/v2/Git-Basics-Tagging).
+o view the most recent release tag, execute the following.
+
+```shell
+git describe master --match "v*" --tags
+```
+
+## Releases
+
+Releases are accomplished through GitHub Actions.
+
+To initiate a release, create a manual tag use the following steps. The `<MAJOR>.<MINOR>.<PATCH>` values **MUST** follow semantic versioning.
+
+    git tag v<MAJOR>.<MINOR>.<PATCH>
+    git push origin v<MAJOR>.<MINOR>.<PATCH>
+
+Once pushed, a GitHub Action will be trigged. This action with publish the release to [PyPi](https://pypi.org/project/rsconnect-jupyter/) using the specified version.
+
+### Releasing on Conda Forge
+
+`rsconnect-jupyter` exists on conda-forge as its own [feedstock](https://github.com/conda-forge/rsconnect-jupyter-feedstock)
 
 Updating the package requires a fork of the repository and a push request [example workflow](https://conda-forge.org/docs/maintainer/updating_pkgs.html#example-workflow-for-updating-a-package). 
 
@@ -60,7 +99,7 @@ Updating the package requires a fork of the repository and a push request [examp
 
 - For a rebuild of the same version, increase "number" under "build" by one in the [meta.yaml](https://github.com/conda-forge/rsconnect-jupyter-feedstock/blob/master/recipe/meta.yaml) file.
 
-
 ### Adding yourself as a rsconnect-jupyter conda-forge maintainer
 
 Add your github username under recipe-maintainers in the [meta.yaml](https://github.com/conda-forge/rsconnect-jupyter-feedstock/blob/master/recipe/meta.yaml) file.
+


### PR DESCRIPTION
### Description

Adds deployment instructions to CONTRIBUTING.md.

I have also added a table of contents using the [markdown-toc](https://github.com/ardumont/markdown-toc) emacs plugin.
