### PR TITLE
add repo name to Snyk project name

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -20,7 +20,7 @@ jobs:
         uses: snyk/actions/python@master
         with:
           command: monitor
-          args: --file=requirements-dev.txt --project-name=python --org=${{ env.SNYK_ORG }}
+          args: --file=requirements-dev.txt --project-name=rsconnect-jupyter --org=${{ env.SNYK_ORG }}
   ui:
     runs-on: ubuntu-latest
     steps:
@@ -32,4 +32,4 @@ jobs:
         uses: snyk/actions/node@master
         with:
           command: monitor
-          args: --file=yarn.lock --project-name=ui --org=${{ env.SNYK_ORG }}
+          args: --file=yarn.lock --project-name=rsconnect-jupyter --org=${{ env.SNYK_ORG }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

The Snyk reports include projects named things like "requirements.txt" and "Pipfile" with no indication of which git repo they originate from.

## Type of Change

- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

Update project name in snyk.yml.

## Automated Tests

No tests since this is a GHA configuration change.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
