### PR TITLE
Revert "add repo name to Snyk project name"

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -20,7 +20,7 @@ jobs:
         uses: snyk/actions/python@master
         with:
           command: monitor
-          args: --file=requirements-dev.txt --project-name=rsconnect-jupyter --org=${{ env.SNYK_ORG }}
+          args: --file=requirements-dev.txt --project-name=python --org=${{ env.SNYK_ORG }}
   ui:
     runs-on: ubuntu-latest
     steps:
@@ -32,4 +32,4 @@ jobs:
         uses: snyk/actions/node@master
         with:
           command: monitor
-          args: --file=yarn.lock --project-name=rsconnect-jupyter --org=${{ env.SNYK_ORG }}
+          args: --file=yarn.lock --project-name=ui --org=${{ env.SNYK_ORG }}


### PR DESCRIPTION
This reverts commit f5ea8d842fca71c984dac52418efca72f45186f5.

## Intent

- Project "groups" are determined by the root repo (which is what we want)
- Project "names" should be unique for each manifest scan, so there should be a separate named project for "ui" and for "python", which will be grouped under "rstudio/rsconnect-jupyter"

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Other: CI

## Approach

N/A

## Automated Tests

N/A

## Directions for Reviewers

N/A