### PR TITLE
Fix minimal typo in docs index

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -78,7 +78,7 @@ The following example shows how to launch a Docker container running _JupyterHub
 
 !!! Warning
 
-    This configuration is **NOT** intended for production usage. This is a minmal working configuration designed to highlight `rsconnect-jupyter` configuration.
+    This configuration is **NOT** intended for production usage. This is a minimal working configuration designed to highlight `rsconnect-jupyter` configuration.
 
 !!! Example "Docker Example"
 


### PR DESCRIPTION
Fixes a typo `minmal => minimal`.

Caught this while I was perusing through documentation for onboarding.

## Type of Change

- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

None of the above are applicable to this change, this only affects documentation.

## Approach

Not applicable here, only documentation has changed.

## Automated Tests

Not applicable here, only documentation has changed.

## Directions for Reviewers

Verify that this is the correct spelling of the intended word.
